### PR TITLE
fix(kore-picker): namespace KorePickers to window

### DIFF
--- a/UI/chatWindow.js
+++ b/UI/chatWindow.js
@@ -1374,7 +1374,7 @@
                 });*/
 
                   // dateClockPickers();
-                  if (KorePickers) {
+                  if (window.KorePickers) {
                     var pickerConfig={
                      chatWindowInstance: me,
                       chatConfig: me.config,


### PR DESCRIPTION
to avoid uncaught reference errors when kore-picker.js is not included in build

kore-picker