### PR TITLE
fix(sync-history): reset this.historySyncInProgress flag

### DIFF
--- a/kore-bot-sdk-client.js
+++ b/kore-bot-sdk-client.js
@@ -47,6 +47,7 @@ inherits(KoreBot, EventEmitter);
 
 KoreBot.prototype.emit = function emit() {
 	if(arguments && arguments[0] === 'history' && this.historySyncInProgress){
+    this.historySyncInProgress = false;
     arguments[2]="historysync";
     this.cbBotChatHistory(arguments);
   }else if(!window._chatHistoryLoaded && arguments && arguments[0] === 'history') {


### PR DESCRIPTION
historySyncInProgress needs to be set to false after emitting "history" event. Otherwise, getHistory does not escape "sync history" flow.

sync-history