### PR TITLE
video upload issue fix in IOS

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -9,6 +9,7 @@ on:
       - v2/dev 
       - v2/dev-rc1
       - v3/dev
+      - v3/iosvid
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -9,7 +9,6 @@ on:
       - v2/dev 
       - v2/dev-rc1
       - v3/dev
-      - v3/iosvid
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/examples/esm/chat/js/index_chat.js
+++ b/examples/esm/chat/js/index_chat.js
@@ -6,11 +6,12 @@ let chatWindowInstance = new chatWindow();
 //OPTION #1
 let botOptions=chatConfig.botOptions;
 
-botOptions.JWTUrl = "PLEASE_ENTER_JWTURL_HERE"; 
-botOptions.userIdentity = 'PLEASE_ENTER_USER_EMAIL_ID';// Provide users email id here
-botOptions.botInfo = { name: "PLEASE_ENTER_BOT_NAME", "_id": "PLEASE_ENTER_BOT_ID" }; // bot name is case sensitive
-botOptions.clientId = "PLEASE_ENTER_CLIENT_ID";
-botOptions.clientSecret = "PLEASE_ENTER_CLIENT_SECRET";
+botOptions.koreAPIUrl = "https://platform.kore.ai/api/";
+botOptions.JWTUrl = "https://mk2r2rmj21.execute-api.us-east-1.amazonaws.com/dev/users/sts";
+botOptions.userIdentity = 'venkateswara.velidi@kore.com';// Provide users email id here
+botOptions.botInfo = { name: "SDKDemo", "_id": "st-f59fda8f-e42c-5c6a-bc55-3395c109862a" }; // bot name is case sensitive
+botOptions.clientId = "cs-8fa81912-0b49-544a-848e-1ce84e7d2df6";
+botOptions.clientSecret = "DnY4BIXBR0Ytmvdb3yI3Lvfri/iDc/UOsxY2tChs7SY=";
 
 
 /* 

--- a/src/plugins/fileUploader/multiFileUploader.ts
+++ b/src/plugins/fileUploader/multiFileUploader.ts
@@ -485,7 +485,20 @@ class KoreMultiFileUploaderPlugin {
     uploadConfig.chunkUpload = selectedFile.componentSize > me.appConsts.CHUNK_SIZE;
     uploadConfig.file = _file;
     
-    // Always read base64 for media files
+    // If resulttype is already set (e.g., for Safari iOS videos), use it directly
+    if (selectedFile.resulttype) {
+      if (uploadConfig.chunkUpload) {
+        me.createElement(selectedFile);
+        ele = me.hostInstance.chatEle.querySelector('#uid' + selectedFile.uniqueId);
+        me.initiateRcorder(selectedFile, ele);
+        me.multifileuploader(uploadConfig, ele);
+      } else {
+        me.acceptFileRecording(selectedFile);
+      }
+      return;
+    }
+    
+    // Read base64 for media files if not already set
     var reader: any = new FileReader();
     reader.onloadend = function (evt: any) {
       if (evt.target.readyState === FileReader.DONE) {

--- a/src/plugins/fileUploader/multiFileUploader.ts
+++ b/src/plugins/fileUploader/multiFileUploader.ts
@@ -413,7 +413,9 @@ class KoreMultiFileUploaderPlugin {
             const img = new Image();
             img.src = url;
             img.onload = function () {
-              recState.resulttype = me.getDataURL(img);
+              const dataUrl = me.getDataURL(img);
+              // Extract base64 part from data URL (getDataURL returns "data:image/png;base64,...")
+              recState.resulttype = dataUrl.replace(/^.*;base64,/, '');
               me.getFileToken(recState, selectedFile);
             };
           };

--- a/src/plugins/fileUploader/multiFileUploader.ts
+++ b/src/plugins/fileUploader/multiFileUploader.ts
@@ -339,12 +339,15 @@ class KoreMultiFileUploaderPlugin {
       let uploadFn;
       if ((me.filetypes.image.indexOf(recState.fileType) > -1)) {
         recState.type = 'image';
+        recState.componentSize = selectedFile.size;
         recState.uploadFn = 'acceptFileRecording';
       } else if ((me.filetypes.video.indexOf(recState.fileType) > -1)) {
         recState.type = 'video';
+        recState.componentSize = selectedFile.size;
         recState.uploadFn = 'acceptVideoRecording';
       } else if ((me.filetypes.audio.indexOf(recState.fileType) > -1)) {
         recState.type = 'audio';
+        recState.componentSize = selectedFile.size;
         recState.uploadFn = 'acceptFile';
       } else {
         recState.type = 'attachment';
@@ -466,23 +469,24 @@ class KoreMultiFileUploaderPlugin {
     uploadConfig.chunkSize = me.appConsts.CHUNK_SIZE;
     uploadConfig.chunkUpload = selectedFile.componentSize > me.appConsts.CHUNK_SIZE;
     uploadConfig.file = _file;
-    if (uploadConfig.chunkUpload) {
-      me.createElement(selectedFile);
-      ele = me.hostInstance.chatEle.querySelector('#uid' + selectedFile.uniqueId);
-      me.initiateRcorder(selectedFile, ele);
-      me.multifileuploader(uploadConfig, ele);
-    } else {
-      var reader: any = new FileReader();
-      reader.onloadend = function (evt: any) {
-        if (evt.target.readyState === FileReader.DONE) { // DONE == 2
-          var converted = reader.result.replace(/^.*;base64,/, '');
-          var resultGet = converted;
-          selectedFile.resulttype = resultGet;
+    
+    // Always read base64 for media files
+    var reader: any = new FileReader();
+    reader.onloadend = function (evt: any) {
+      if (evt.target.readyState === FileReader.DONE) {
+        var converted = reader.result.replace(/^.*;base64,/, '');
+        selectedFile.resulttype = converted;
+        if (uploadConfig.chunkUpload) {
+          me.createElement(selectedFile);
+          ele = me.hostInstance.chatEle.querySelector('#uid' + selectedFile.uniqueId);
+          me.initiateRcorder(selectedFile, ele);
+          me.multifileuploader(uploadConfig, ele);
+        } else {
           me.acceptFileRecording(selectedFile);
         }
-      };
-      reader.readAsDataURL(_file);
-    }
+      }
+    };
+    reader.readAsDataURL(_file);
   }
 
   getfileuploadConf(_recState: { fileType: any; name: any; fileToken?: any; }) {

--- a/src/templatemanager/templates/message/message.tsx
+++ b/src/templatemanager/templates/message/message.tsx
@@ -278,8 +278,8 @@ export function Message(props: any) {
                                             <div className="attchment-details">
                                                 <div className="content-info">
                                                     { attachment.fileType == 'video' && 
-                                                        <video width="240" height="145" controls>
-                                                            <source src={attachment.fileContentBase64 || attachment.fileUrl}></source>
+                                                        <video width="240" height="145" controls playsInline>
+                                                            <source src={attachment.fileContentBase64 || attachment.fileUrl} type={attachment.fileContentBase64 ? attachment.fileContentBase64.split(';')[0].split(':')[1] : 'video/mp4'}></source>
                                                         </video>
                                                     }
                                                     <h1>{attachment.fileName}</h1>

--- a/src/templatemanager/templates/message/message.tsx
+++ b/src/templatemanager/templates/message/message.tsx
@@ -63,14 +63,38 @@ export function Message(props: any) {
         }, 800);
     }
 
-    const download = (url: any, filename: any) => {
+    const download = (url: any, filename: any, base64Data?: any) => {
         let link = document.createElement("a");
         link.download = filename;
         link.target = "_blank";
-        link.href = url;
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
+        
+        if (base64Data && base64Data.startsWith('data:')) {
+            // Handle base64 data URL
+            const base64String = base64Data.split(',')[1];
+            const mimeType = base64Data.split(',')[0].split(':')[1].split(';')[0];
+            const byteCharacters = atob(base64String);
+            const byteNumbers = new Array(byteCharacters.length);
+            for (let i = 0; i < byteCharacters.length; i++) {
+                byteNumbers[i] = byteCharacters.charCodeAt(i);
+            }
+            const byteArray = new Uint8Array(byteNumbers);
+            const blob = new Blob([byteArray], { type: mimeType });
+            const blobUrl = URL.createObjectURL(blob);
+            link.href = blobUrl;
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            // Clean up the object URL after a short delay
+            setTimeout(() => URL.revokeObjectURL(blobUrl), 100);
+        } else if (url) {
+            // Handle regular URL
+            link.href = url;
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+        } else {
+            console.warn('No download URL or base64 data available');
+        }
     }
 
     let botStyles = {
@@ -232,7 +256,7 @@ export function Message(props: any) {
                                                     <h2>{attachment.fileName}</h2>
                                                     <p>{`${attachment.size} MB`}</p>
                                                 </div>
-                                                <button className="kr-button-blue-light" onClick={() => download(attachment.fileUrl, attachment.fileName?.split('.')?.[0] || 'file')}>{hostInstance.config.botMessages.download}</button>
+                                                <button className="kr-button-blue-light" onClick={() => download(attachment.fileUrl, attachment.fileName || 'file', attachment.fileContentBase64)}>Download</button>
                                             </div>
                                         </div>
                                     </section>
@@ -265,7 +289,7 @@ export function Message(props: any) {
                                                         </audio> }
                                                     <p>{`${attachment.size} MB`}</p>
                                                 </div>
-                                                <button className="kr-button-blue-light" onClick={() => download(attachment.fileUrl, attachment.fileName?.split('.')?.[0] || 'file')}>{hostInstance.config.botMessages.download}</button>
+                                                <button className="kr-button-blue-light" onClick={() => download(attachment.fileUrl, attachment.fileName || 'file', attachment.fileContentBase64)}>Download</button>
                                             </div>
                                         </div>
                                     </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Detects iOS Safari and uploads videos via DataURL, reworks upload prep to use precomputed base64 (incl. chunking), and ensures `componentSize` is set for media files.
> 
> - **File uploader (`src/plugins/fileUploader/multiFileUploader.ts`)**:
>   - **iOS Safari handling**:
>     - Adds `isSafariIOS()` to detect Safari on iOS.
>     - For `video` on iOS Safari, reads file via `FileReader.readAsDataURL` and sets `recState.resulttype` directly (avoids canvas path), then proceeds to token/upload.
>   - **Upload preparation**:
>     - `prepareUploadConfig(...)` now uses existing `selectedFile.resulttype` when present and branches correctly for chunked vs non-chunked uploads.
>     - Falls back to reading base64 via `FileReader.readAsDataURL` to populate `resulttype` before upload when not already set.
>   - **Metadata consistency**:
>     - Ensures `componentSize` is set for `image`, `video`, and `audio` types to drive chunking decisions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63cc3ac2693bfd26d5a34ac4a766972df30292b1. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->