### PR TITLE
PWC Analytics Dashboard Support

### DIFF
--- a/src/plugins/proactiveWebCampaign/proactiveWebCampaign.ts
+++ b/src/plugins/proactiveWebCampaign/proactiveWebCampaign.ts
@@ -3798,7 +3798,7 @@ class ProactiveWebCampaignPlugin {
                 || suppressionResponse.isChatWindowOpen 
                 || suppressionResponse.isCooldownActive 
                 || suppressionResponse.isVisitorAlreadyChatting
-                || suppressionResponse.isCampaignInOperationalHours
+                || !suppressionResponse.isCampaignInOperationalHours
             ){
                 const existingPweData = JSON.parse(window.sessionStorage.getItem('pwe_data') || '{}');
                 let campInstanceId = response.response.body.campInfo.campInstId;

--- a/src/plugins/proactiveWebCampaign/templates/pwcBannerTemplate/pwcBannerTemplate.tsx
+++ b/src/plugins/proactiveWebCampaign/templates/pwcBannerTemplate/pwcBannerTemplate.tsx
@@ -34,6 +34,11 @@ export function Banner(props: any) {
             // Remove from DOM
             const bannerEle: any = document.querySelector('.campaign-banner-sec');
             bannerEle.remove();
+            hostInstance.plugins.ProactiveWebCampaignPlugin.recordCampaignMetric(
+                msgData.body.campInfo.campInstId,
+                msgData.body.campInfo.campId,
+                { eventInfo: { action: 'close', data: {} } }
+            );
         }
         return (
             <div className={bannerClass}>
@@ -43,7 +48,7 @@ export function Banner(props: any) {
                         <p dangerouslySetInnerHTML={{__html: ele.value}}></p>
                         ))}
                     </div>
-                    <button className="close_banner" onClick={closeBanner}>
+                    <button className="close_banner" onClick={() => closeBanner()}>
                         <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
                             <path d="M8.70703 8.00009L12.8536 3.85355C13.0488 3.65829 13.0488 3.34171 12.8536 3.14645C12.6583 2.95118 12.3417 2.95118 12.1464 3.14645L7.99991 7.293L3.85355 3.14681C3.65829 2.95156 3.34171 2.95156 3.14645 3.14683C2.95119 3.34209 2.9512 3.65868 3.14646 3.85393L7.2928 8.0001L3.14645 12.1465C2.95118 12.3417 2.95118 12.6583 3.14645 12.8536C3.34171 13.0488 3.65829 13.0488 3.85355 12.8536L7.99992 8.7072L12.1465 12.8536C12.3417 13.0488 12.6583 13.0488 12.8536 12.8536C13.0488 12.6583 13.0488 12.3417 12.8536 12.1464L8.70703 8.00009Z" fill="white"/>
                         </svg>

--- a/src/plugins/proactiveWebCampaign/templates/pwcButtonTemplate/pwcButtonTemplate.tsx
+++ b/src/plugins/proactiveWebCampaign/templates/pwcButtonTemplate/pwcButtonTemplate.tsx
@@ -25,13 +25,15 @@ export function Button(props: any) {
         layoutDesign.buttons = btns;
 
         const handleClick = (btn: any, ind: any) => {
+            let buttonActionType = '';
             if (btn.actionType == 'url') {
                 let link = btn.actionValue;
                 if (link.indexOf('http:') < 0 && link.indexOf('https:') < 0) {
                     link = `http:////${link}`;
                 }
                 hostInstance.openExternalLink(link);
-                removeButton(ind)
+                buttonActionType = 'sendToUrl';
+                removeButton(ind, false);
             } else {
                 layoutDesign.buttons.forEach((button: any, index: number)=>{
                     const cbtn: any = document.getElementById(`campaign-button-${index}`);
@@ -43,10 +45,20 @@ export function Button(props: any) {
                 if (btn) {
                     btn.classList.add('show-campaign-content-data');
                 }
+                buttonActionType = 'slideOutMessage';
             }
+            recordCampaignMetric(msgData?.body?.campInfo?.campInstId, msgData?.body?.campInfo?.campId, { action: 'click', data: { buttonActionType } });
         }
 
-        const removeButton = (ind: any) => {
+        const recordCampaignMetric = (campInstId: string, campId: string, eventInfo: any) => {
+            hostInstance.plugins.ProactiveWebCampaignPlugin.recordCampaignMetric(
+                campInstId,
+                campId,
+                { eventInfo: eventInfo }
+            );
+        }
+
+        const removeButton = (ind: any, sendEvent = false) => {
             // Clear from sessionStorage
             hostInstance.plugins.ProactiveWebCampaignPlugin.clearPersistedTemplateFromStorage();
             
@@ -54,6 +66,10 @@ export function Button(props: any) {
             const btn = document.getElementById(`campaign-button-${ind}`);
             if (btn) {
                 btn.remove();
+            }
+
+            if (sendEvent) {
+                recordCampaignMetric(msgData?.body?.campInfo?.campInstId, msgData?.body?.campInfo?.campId, { action: 'close', data: {} });
             }
         }
 
@@ -66,7 +82,7 @@ export function Button(props: any) {
                             <div className="heading-block-info">
                                 {btn.headerUpload === 'upload' && <img src={btn.headerIcon}></img>}
                                 <h1>{btn?.headerMessage}</h1>
-                                <button onClick={() => removeButton(ind)}>
+                                <button onClick={() => removeButton(ind, true)}>
                                     <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
                                         <path d="M18 6L6 18M6 6L18 18" stroke="#667085" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
                                     </svg>

--- a/src/plugins/proactiveWebCampaign/templates/pwcPostTemplate/pwcPostTemplate.tsx
+++ b/src/plugins/proactiveWebCampaign/templates/pwcPostTemplate/pwcPostTemplate.tsx
@@ -31,12 +31,18 @@ export function Post(props: any) {
             // Remove from DOM
             const bannerEle: any = document.querySelector('.campaign-post-banner-data-sec');
             bannerEle.remove();
+
+            hostInstance.plugins.ProactiveWebCampaignPlugin.recordCampaignMetric(
+                msgData.body.campInfo.campInstId,
+                msgData.body.campInfo.campId,
+                { eventInfo: { action: 'close', data: {} } }
+            );
         }
         return (
             <div className={postClass}>
                 <div className="post-banner-data">
                     <div className="header-block-info">
-                        <button className="close-post-banner" onClick={closePost}>
+                        <button className="close-post-banner" onClick={() => closePost()}>
                             <svg width="19" height="19" viewBox="0 0 19 19" fill="none">
                                 <path d="M13.2985 5.70215L5.74023 13.2604M5.74023 5.70215L13.2985 13.2604" stroke="#101828" stroke-width="1.51166" stroke-linecap="round" stroke-linejoin="round"/>
                             </svg>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds lightweight client-side analytics for proactive web campaigns and simplifies event payload construction.
> 
> - New `recordCampaignMetric(campInstanceId, campId, { eventInfo })` and `preparePwePayload(...)`; `triggerCampaignEvent` now uses `preparePwePayload` and includes `eventInfo: impression` and `isLoggedInUser`
> - Templates (`pwcBannerTemplate`, `pwcPostTemplate`, `pwcButtonTemplate`, `pwcChatTemplate`) now send `eventInfo` for `click`/`close` with context (e.g., `buttonActionType`, `channelType`)
> - Suppression expands to include `!isCampaignInOperationalHours`; client `getActiveCampaigns` no longer enforces engagement hours (validated server-side)
> - Minor handlers adjusted (close/click wiring) and sessionStorage cleanup preserved
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79781e8e92bf0dd6c63693d96fb51882980ac288. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->