### PR TITLE
added kore custom table template

### DIFF
--- a/docs/templates/tableTemplate/README.md
+++ b/docs/templates/tableTemplate/README.md
@@ -21,7 +21,7 @@ var message = {
         "columns": [
             ["Sl", "center"], ["Name"], ["Designation"], ["Salary", "right"]
         ],
-        "table_design": "regular",
+        "table_design": "regular", // regular, responsive
         speech_hint: "Here is your account details",
         elements: []
     }
@@ -30,6 +30,51 @@ var ele = [];
 for (var i = 0; i < elements.length; i++) {
     var elementArr = [elements[i].id, elements[i].name, elements[i].designation, elements[i].salary];
     ele.push({'Values': elementArr});
+}
+message.payload.elements = ele;
+print(JSON.stringify(message));
+```
+
+
+
+##  Kore Custom Table template
+
+Table template with postback and clickable urls
+
+###### Preview
+
+<img width="417" height="897" alt="image" src="https://github.com/user-attachments/assets/e9a64b23-537d-483e-a107-65501aa81d98" />
+
+###### Message Payload
+
+```js
+let elements = [
+  { id: "1", name: "Peter", designation: "Producer", salary: 1000 },
+  { id: "2", name: "Sam", designation: "Director", salary: 2000 },
+  { id: "3", name: "Nick", designation: "DoP", salary: 1500 },
+  { id: "4", name: "Peter", designation: "Producer", salary: 1000 },
+  { id: "5", name: "Sam", designation: "Director", salary: 2000 },
+  { id: "6", name: "Nick", designation: "DoP", salary: 1500 }
+];
+let message = {
+  "type": "template",
+  "payload": {
+    "template_type": "custom_table",
+    "text": "Account details",
+    "columns": [["Sl", "center"], ["Name"], ["Designation"], ["Salary", "right"]],
+    "table_design": "regular", // regular only
+    speech_hint: "Here is your account details",
+    elements: []
+  }
+};
+let ele = [];
+for (let i = 0; i < elements.length; i++) {
+  let elementArr = [
+    [elements[i].id, "text"],
+    [elements[i].name, "text"],
+    [elements[i].designation, "button", { "type": "web_url", "title": "click", "url": "https://www.kore.ai" }],
+    [elements[i].salary, "button", { "type": "postback", "title": "click", "payload": "id1" }]];
+  ele.push({ 'Values': elementArr });
 }
 message.payload.elements = ele;
 print(JSON.stringify(message));

--- a/src/templatemanager/templates/table/table.scss
+++ b/src/templatemanager/templates/table/table.scss
@@ -160,3 +160,7 @@
     background: transparent;
     cursor: pointer;
 }
+
+.kore-chat-window-main-section .show-more-btn{
+    @extend .show-more-btn;
+}

--- a/src/templatemanager/templates/table/table.scss
+++ b/src/templatemanager/templates/table/table.scss
@@ -43,6 +43,14 @@
             font-size: 12px;
             font-weight: 400;
             line-height: 18px;
+            &.clickable-btn{
+                cursor: pointer;
+                color: var(--sdk-global-theme-color);
+                font-weight: 500;
+            }
+            &.clickable-link{
+                text-decoration: underline;
+            }
         }
     }
 }

--- a/src/templatemanager/templates/table/table.tsx
+++ b/src/templatemanager/templates/table/table.tsx
@@ -82,6 +82,59 @@ export function TableExt(props: any) {
                 </div>
             </Fragment>
         );
+    } else if (msgData.message?.[0]?.component?.payload?.template_type == 'custom_table' && msgData.message[0].component.payload?.table_design == 'regular') {
+        const payload = msgData.message[0].component.payload;
+        const handleCellClick = (cellValue: any) => {
+            if (cellValue[1] === 'button' && cellValue[2]) {
+                if (cellValue[2].type === 'web_url' && cellValue[2].url) {
+                    let link = cellValue[2].url;
+                    if (link.indexOf('http:') < 0 && link.indexOf('https:') < 0) {
+                        link = `https://${link}`;
+                    }
+                    hostInstance.openExternalLink(link);
+                } else if (cellValue[2].type === 'postback') {
+                    hostInstance.sendMessage(cellValue[2].payload, { renderMsg: cellValue[2].title });
+                }
+            }
+        }
+        return (
+            <Fragment>
+                <section class="table-wrapper-main-container" data-cw-msg-id={msgData?.messageId}>
+                    {showMore && msgData?.message?.[0]?.cInfo?.body && <Message {...messageObj} />}
+                    <section class="table-wrapper-section">
+                        <div style="overflow-x:auto; padding: 0 8px;">
+                            <table className="table-regular-view" cellSpacing={0} cellPadding={0}>
+                                <thead>
+                                    <tr>
+                                        {payload.columns.map((col: any) => (
+                                            <th style={col[1] ? { textAlign: col[1] } : {}}
+                                                dangerouslySetInnerHTML={{ __html: helpers.convertMDtoHTML(col[0] || "", "bot") }}></th>
+                                        ))}
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {payload.elements.map((row: any, rowIdx: any) => (
+                                        row.Values?.length > 1 && ((showMore && rowIdx < 3) || !showMore) &&
+                                        <tr>
+                                            {row.Values.map((cell: any, cellIdx: any) => (
+                                                <td
+                                                    className={cell[1] === 'button' ? `clickable-btn${cell[2]?.type === 'web_url' ? ' clickable-link' : ''}` : ''}
+                                                    style={payload.columns[cellIdx]?.[1] ? { textAlign: payload.columns[cellIdx][1] } : {}}
+                                                    title={cell[0]}
+                                                    onClick={() => cell[1] === 'button' && handleCellClick(cell)}
+                                                    dangerouslySetInnerHTML={{ __html: helpers.convertMDtoHTML(String(cell[0] ?? ""), "bot") }}>
+                                                </td>
+                                            ))}
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        </div>
+                        {showMore && payload.elements.length > 3 && <button className={`show-more-btn table-show-more-${msgData.messageId}`}>Show More</button>}
+                    </section>
+                </section>
+            </Fragment>
+        );
     } else {
         return null;
     }
@@ -97,6 +150,21 @@ export function Table(props: any) {
     }
 
     if (msgData.message?.[0]?.component?.payload?.template_type == 'table') {
+        useEffect(() => {
+            setTimeout(() => {
+                msgData.message[0].component.payload.table_design = 'regular';
+                hostInstance.chatEle.querySelector(`.table-show-more-${msgData.messageId}`)?.addEventListener('click', (e: any) => {
+                    hostInstance.modalAction(getHTML(TableExt, msgData, hostInstance));
+                });
+            }, 500);
+        });
+        msgObj.msgData.message[0].cInfo.body = msgObj.msgData.message[0].component?.payload?.text || '';
+        return (
+            <Fragment>
+                <TableExt {...msgObj} />
+            </Fragment>
+        )
+    } else if (msgData.message?.[0]?.component?.payload?.template_type == 'custom_table') {
         useEffect(() => {
             setTimeout(() => {
                 msgData.message[0].component.payload.table_design = 'regular';

--- a/src/templatemanager/templates/table/table.tsx
+++ b/src/templatemanager/templates/table/table.tsx
@@ -102,7 +102,6 @@ export function TableExt(props: any) {
                 <section class="table-wrapper-main-container" data-cw-msg-id={msgData?.messageId}>
                     {showMore && msgData?.message?.[0]?.cInfo?.body && <Message {...messageObj} />}
                     <section class="table-wrapper-section">
-                        <div style="overflow-x:auto; padding: 0 8px;">
                             <table className="table-regular-view" cellSpacing={0} cellPadding={0}>
                                 <thead>
                                     <tr>
@@ -129,7 +128,6 @@ export function TableExt(props: any) {
                                     ))}
                                 </tbody>
                             </table>
-                        </div>
                         {showMore && payload.elements.length > 3 && <button className={`show-more-btn table-show-more-${msgData.messageId}`}>Show More</button>}
                     </section>
                 </section>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new message template variant that can open external URLs and send postback payloads on cell click, which touches user interaction and outbound navigation paths. Risk is moderate due to new click-handling logic and potential URL/payload validation edge cases.
> 
> **Overview**
> Adds support for a new `custom_table` message template rendered in the existing table UI, where individual cells can be plain text or interactive "button" cells that either open a `web_url` or trigger a `postback` via `hostInstance.sendMessage`.
> 
> Updates table styling to visually indicate clickable cells (link/underline + pointer cursor) and documents the new payload format and options in `docs/templates/tableTemplate/README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a4e39a84d99e7db753188b3803a9e9b780cc1e2. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->