### PR TITLE
Video call recording support

### DIFF
--- a/src/plugins/agentDesktop/agentdesktop-script.js
+++ b/src/plugins/agentDesktop/agentdesktop-script.js
@@ -1149,10 +1149,9 @@ AgentDesktop = function (uuId, aResponse) {
                 });
                 localStorage.setItem("pagesVisited", JSON.stringify(pagesVisitedArray))
             } else if (msgJson.type === 'events' && msgJson.message && msgJson.message.type === 'video_call_recording_request') {
-                console.log("video_call_recording_request", msgJson.message);
                 const cwInstance = this.config.hostInstance;
                 if (!cwInstance?.chatEle?.querySelector('.custom-slider-modal')) {
-                    openCustomSliderModal(cwInstance, { variant: 'warning' });
+                    openCustomSliderModal(cwInstance, { variant: 'warning', emitOnPrimary: 'video_call_recording_proceed', emitOnSecondary: 'video_call_recording_decline' });
                 }
             } else if (msgJson.type === 'events' && msgJson.message && msgJson.message.type === 'video_call_recording_request_timeout') {
                 closeRecordingConsentSlider();
@@ -1458,9 +1457,9 @@ AgentDesktop = function (uuId, aResponse) {
             stream.getTracks().forEach(function (track) {
                 track.stop();
             });
-            if(this.callDetails.videoCall){
+            if (this.callDetails.videoCall) {
                 this.activeCall = this.phone.call(this.phone.VIDEO, sipUser, [`X-botName:${this.callDetails?.botId || ''}`, `X-cId:${this.callDetails?.conversationId || ''}`, `X-isVideoCall:true`]);
-            }else{
+            } else {
                 this.activeCall = this.phone.call(this.phone.AUDIO, sipUser);
             }
         });

--- a/src/plugins/agentDesktop/agentdesktop-script.js
+++ b/src/plugins/agentDesktop/agentdesktop-script.js
@@ -394,6 +394,13 @@ AgentDesktop = function (uuId, aResponse) {
         `<div id="video_view" class="video-view-">
             <video id="kore_remote_video_tmp" autoplay="autoplay" playsinline style="display: block;"></video>
             <div class="action-minimize-audio-control">
+                <div class="recording-video-info">
+                    <div class="recording-tooltip">This call is being recorded.</div>
+                    <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                        <path d="M6 0.5C2.96243 0.5 0.5 2.96243 0.5 6C0.5 9.03757 2.96243 11.5 6 11.5C9.03757 11.5 11.5 9.03757 11.5 6C11.5 2.96243 9.03757 0.5 6 0.5Z" fill="#D92D20"/>
+                    </svg>
+                    <p>Rec</p>
+                </div>
                 <div id="maximizevideo" class="maximize-video">
                     <span class="maximize-icon">
                         <svg width="12" height="12" viewBox="0 0 12 12" fill="none">

--- a/src/plugins/agentDesktop/agentdesktop-script.js
+++ b/src/plugins/agentDesktop/agentdesktop-script.js
@@ -147,6 +147,7 @@ import requireKr from '../../components/base-sdk/kore-bot-sdk-client';
 import './agentdesktop.css';
 import moment from 'moment';
 import { pack } from '@amplitude/rrweb-packer';
+import { openCustomSliderModal } from '../../templatemanager/base/customSliderModal/customSliderModal.tsx';
 
 /** @ignore */
 class AgentDesktopPluginScript  {
@@ -199,6 +200,44 @@ AgentDesktop = function (uuId, aResponse) {
     this.authResponse = null;
     let cwInstance = this.config.hostInstance;
     let botInstance = cwInstance?.bot;
+    if (!this.config.isVoiceCobrowseSession && cwInstance && typeof cwInstance.on === 'function') {
+        cwInstance.on('video_call_recording_proceed', () => {
+            try {
+                const activeBotInstance = cwInstance?.bot || botInstance;
+                if (!activeBotInstance || typeof activeBotInstance.sendMessage !== 'function') {
+                    return;
+                }
+                const messageToBot = {};
+                messageToBot["event"] = "event";
+                messageToBot["message"] = {
+                    "body": { type: "video_call_recording_accepted" },
+                    "type": ""
+                };
+                activeBotInstance.sendMessage(messageToBot, (err) => { });
+                _self.isVideoCallRecording = true;
+                if (typeof _self.updateVideoCallRecordingUI === 'function') {
+                    _self.updateVideoCallRecordingUI();
+                }
+            } catch (e) {
+                console.log("Failed to send video_call_recording_accepted", e);
+            }
+        });
+        cwInstance.on('video_call_recording_decline', () => {
+            const activeBotInstance = cwInstance?.bot || botInstance;
+            if (!activeBotInstance?.sendMessage) return;
+            const messageToBot = {};
+            messageToBot["event"] = "event";
+            messageToBot["message"] = {
+              body: { type: "video_call_recording_declined" },
+              type: ""
+            };
+            activeBotInstance.sendMessage(messageToBot, () => {});
+            _self.isVideoCallRecording = false;
+            if (typeof _self.updateVideoCallRecordingUI === 'function') {
+                _self.updateVideoCallRecordingUI();
+            }
+        });
+    }
     console.log("agentdesktop uuId", uuId);
     /*if (uuId && uuId.length > 0) {
         localStorage.setItem("kr-cw-uid", uuId)
@@ -224,6 +263,52 @@ AgentDesktop = function (uuId, aResponse) {
     this.agentProfileIcon = null;
     this.maskClassList = null;
     this.maskPatternList = null;
+    this.isVideoCallRecording = false;
+    this.isVideoCallRecordingPaused = false;
+
+    this.updateVideoCallRecordingUI = function () {
+        try {
+            const shouldShow = !!(_self.callDetails?.videoCall && _self.isVideoCallRecording);
+            const host = document.querySelector('#audiovideocallcontainer .action-minimize-audio-control');
+            if (!host) return;
+
+            const existing = host.querySelector('.recording-video-info');
+            if (!shouldShow) {
+                if (existing) existing.remove();
+                return;
+            }
+
+            const tooltipText = _self.isVideoCallRecordingPaused ? 'Recording paused' : 'This call is being recorded.';
+            const labelText = _self.isVideoCallRecordingPaused ? 'Rec Paused' : 'Rec';
+
+            if (!existing) {
+                host.insertAdjacentHTML(
+                    'afterbegin',
+                    `<div class="recording-video-info${_self.isVideoCallRecordingPaused ? ' recording-info-paused' : ''}">
+                        <div class="recording-tooltip">${tooltipText}</div>
+                        <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                            <path d="M6 0.5C2.96243 0.5 0.5 2.96243 0.5 6C0.5 9.03757 2.96243 11.5 6 11.5C9.03757 11.5 11.5 9.03757 11.5 6C11.5 2.96243 9.03757 0.5 6 0.5Z" fill="#D92D20"/>
+                        </svg>
+                        <p>${labelText}</p>
+                    </div>`
+                );
+                return;
+            }
+
+            if (_self.isVideoCallRecordingPaused) {
+                existing.classList.add('recording-info-paused');
+            } else {
+                existing.classList.remove('recording-info-paused');
+            }
+
+            const tooltipEl = existing.querySelector('.recording-tooltip');
+            if (tooltipEl) tooltipEl.textContent = tooltipText;
+            const labelEl = existing.querySelector('p');
+            if (labelEl) labelEl.textContent = labelText;
+        } catch (e) {
+            console.log('Failed to update recording UI', e);
+        }
+    };
     this.phoneConfig = {
         reconnectIntervalMin: 2, // Minimum interval between WebSocket reconnection attempts. (seconds)
         reconnectIntervalMax: 30, // Maximum interval between WebSocket reconnection attempts (seconds)
@@ -278,6 +363,11 @@ AgentDesktop = function (uuId, aResponse) {
         callContainer.remove();
         this.removeAudoVideoContainer();
         this.disableMinimizeButton(false);
+        _self.isVideoCallRecording = false;
+        _self.isVideoCallRecordingPaused = false;
+        if (typeof _self.updateVideoCallRecordingUI === 'function') {
+            _self.updateVideoCallRecordingUI();
+        }
         _self.enableClickToCallButton();
     }
     this.showFooterButtons = function (callConnected, videoCall) {
@@ -394,13 +484,6 @@ AgentDesktop = function (uuId, aResponse) {
         `<div id="video_view" class="video-view-">
             <video id="kore_remote_video_tmp" autoplay="autoplay" playsinline style="display: block;"></video>
             <div class="action-minimize-audio-control">
-                <div class="recording-video-info">
-                    <div class="recording-tooltip">This call is being recorded.</div>
-                    <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
-                        <path d="M6 0.5C2.96243 0.5 0.5 2.96243 0.5 6C0.5 9.03757 2.96243 11.5 6 11.5C9.03757 11.5 11.5 9.03757 11.5 6C11.5 2.96243 9.03757 0.5 6 0.5Z" fill="#D92D20"/>
-                    </svg>
-                    <p>Rec</p>
-                </div>
                 <div id="maximizevideo" class="maximize-video">
                     <span class="maximize-icon">
                         <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
@@ -479,6 +562,9 @@ AgentDesktop = function (uuId, aResponse) {
             audiovideocallcontainer.empty();
             if (_self.callDetails.videoCall) {
                 audiovideocallcontainer.append(videoContainerHTML);
+                if (typeof _self.updateVideoCallRecordingUI === 'function') {
+                    _self.updateVideoCallRecordingUI();
+                }
                 koreJquery("#agentyou").hide()
                 var gLocalVideo = document.getElementById('kore_local_video');
                 gLocalVideo["srcObject"] = gLocalVideo["srcObject"]
@@ -939,6 +1025,11 @@ AgentDesktop = function (uuId, aResponse) {
                 }
                 console.log('payload=', msgJson.message);
                 _self.callAccepted = false;
+                _self.isVideoCallRecording = false;
+                _self.isVideoCallRecordingPaused = false;
+                if (typeof _self.updateVideoCallRecordingUI === 'function') {
+                    _self.updateVideoCallRecordingUI();
+                }
                 _self.showPhonePanel = true;
 
                 if (_self.callDetails.restoreCall) {
@@ -956,6 +1047,11 @@ AgentDesktop = function (uuId, aResponse) {
                 _self.removeAudoVideoContainer()
                 _self.showPhonePanel = false;
                 _self.showVideo = false;
+                _self.isVideoCallRecording = false;
+                _self.isVideoCallRecordingPaused = false;
+                if (typeof _self.updateVideoCallRecordingUI === 'function') {
+                    _self.updateVideoCallRecordingUI();
+                }
                 if (_self.activeCall) {
                     _self.activeCall.terminate();
                     _self.phone.deinit();
@@ -1022,6 +1118,22 @@ AgentDesktop = function (uuId, aResponse) {
                     timestamp: new moment()
                 });
                 localStorage.setItem("pagesVisited", JSON.stringify(pagesVisitedArray))
+            } else if (msgJson.type === 'events' && msgJson.message && msgJson.message.type === 'video_call_recording_request') {
+                console.log("video_call_recording_request", msgJson.message);
+                const cwInstance = this.config.hostInstance;
+                if (!cwInstance?.chatEle?.querySelector('.custom-slider-modal')) {
+                    openCustomSliderModal(cwInstance, { variant: 'warning' });
+                }
+            } else if (msgJson.type === 'events' && msgJson.message && msgJson.message.type === 'video_call_recording_resume') {
+                _self.isVideoCallRecordingPaused = false;
+                if (typeof _self.updateVideoCallRecordingUI === 'function') {
+                    _self.updateVideoCallRecordingUI();
+                }
+            } else if (msgJson.type === 'events' && msgJson.message && msgJson.message.type === 'video_call_recording_pause') {
+                _self.isVideoCallRecordingPaused = true;
+                if (typeof _self.updateVideoCallRecordingUI === 'function') {
+                    _self.updateVideoCallRecordingUI();
+                }
             }
         });
     }
@@ -1208,6 +1320,7 @@ AgentDesktop = function (uuId, aResponse) {
                 self.callMuted = false;
                 self.showPhonePanel = false;
                 self.showVideo = false;
+                self.isVideoCallRecording = false;
                 self.screenSharingStream = null;
                 _self.callTerminated();
             },
@@ -1314,7 +1427,7 @@ AgentDesktop = function (uuId, aResponse) {
                 track.stop();
             });
             if(this.callDetails.videoCall){
-                this.activeCall = this.phone.call(this.phone.VIDEO, sipUser);
+                this.activeCall = this.phone.call(this.phone.VIDEO, sipUser, [`X-botName:${this.callDetails?.botId || ''}`, `X-cId:${this.callDetails?.conversationId || ''}`, "X-VideoCall:true"]);
             }else{
                 this.activeCall = this.phone.call(this.phone.AUDIO, sipUser);
             }

--- a/src/plugins/agentDesktop/agentdesktop-script.js
+++ b/src/plugins/agentDesktop/agentdesktop-script.js
@@ -200,6 +200,36 @@ AgentDesktop = function (uuId, aResponse) {
     this.authResponse = null;
     let cwInstance = this.config.hostInstance;
     let botInstance = cwInstance?.bot;
+
+    const closeRecordingConsentSlider = () => {
+        try {
+            if (!cwInstance?.chatEle) {
+                return;
+            }
+            // Only close when the recording consent modal is actually open.
+            if (!cwInstance.chatEle.querySelector('.custom-slider-modal')) {
+                return;
+            }
+
+            if (cwInstance?.config?.UI?.version == 'v2') {
+                if (typeof cwInstance.bottomSliderAction === 'function') {
+                    cwInstance.bottomSliderAction('hide');
+                }
+                return;
+            }
+
+            const wrap = cwInstance.chatEle.querySelector('.chat-actions-bottom-wraper');
+            if (!wrap) {
+                return;
+            }
+            wrap.classList.add('close-bottom-slide');
+            setTimeout(() => {
+                wrap.remove();
+            }, 150);
+        } catch (e) {
+            console.log('Failed to close recording consent slider', e);
+        }
+    };
     if (!this.config.isVoiceCobrowseSession && cwInstance && typeof cwInstance.on === 'function') {
         cwInstance.on('video_call_recording_proceed', () => {
             try {
@@ -1124,6 +1154,8 @@ AgentDesktop = function (uuId, aResponse) {
                 if (!cwInstance?.chatEle?.querySelector('.custom-slider-modal')) {
                     openCustomSliderModal(cwInstance, { variant: 'warning' });
                 }
+            } else if (msgJson.type === 'events' && msgJson.message && msgJson.message.type === 'video_call_recording_request_timeout') {
+                closeRecordingConsentSlider();
             } else if (msgJson.type === 'events' && msgJson.message && msgJson.message.type === 'video_call_recording_resume') {
                 _self.isVideoCallRecordingPaused = false;
                 if (typeof _self.updateVideoCallRecordingUI === 'function') {
@@ -1427,7 +1459,7 @@ AgentDesktop = function (uuId, aResponse) {
                 track.stop();
             });
             if(this.callDetails.videoCall){
-                this.activeCall = this.phone.call(this.phone.VIDEO, sipUser, [`X-botName:${this.callDetails?.botId || ''}`, `X-cId:${this.callDetails?.conversationId || ''}`, "X-VideoCall:true"]);
+                this.activeCall = this.phone.call(this.phone.VIDEO, sipUser, [`X-botName:${this.callDetails?.botId || ''}`, `X-cId:${this.callDetails?.conversationId || ''}`, `X-isVideoCall:true`]);
             }else{
                 this.activeCall = this.phone.call(this.phone.AUDIO, sipUser);
             }

--- a/src/plugins/agentDesktop/agentdesktop.css
+++ b/src/plugins/agentDesktop/agentdesktop.css
@@ -682,6 +682,79 @@
     position: absolute;
     top: 10px;
     right: 10px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.video-audio-chat-container .action-minimize-audio-control .recording-video-info {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    position: relative;
+    border-radius: var(--full, 9999px);
+    border: var(--Border-Stroke-Default, 1px) solid var(--component-colors-utility-error-utility-error-200, #FECDCA);
+    background: var(--component-colors-utility-error-utility-error-50, #FEF3F2);
+    padding: var(--xxs, 2px) var(--default, 8px);
+}
+.video-audio-chat-container .action-minimize-audio-control .recording-video-info.recording-info-paused{
+    border: var(--Border-Stroke-Default, 1px) solid var(--component-colors-utility-gray-utility-gray-200, #EAECF0);
+    background: var(--component-colors-utility-gray-utility-gray-50, #F9FAFB);
+}
+.video-audio-chat-container .action-minimize-audio-control .recording-video-info.recording-info-paused svg path{ 
+    fill: #98A2B3;
+}
+.video-audio-chat-container .action-minimize-audio-control .recording-video-info.recording-info-paused p{
+    color: var(--component-colors-utility-gray-utility-gray-700, #344054);
+    text-align: center;
+    font-size: var(--font-size-text-xs, 12px);
+    font-weight: var(--font-weight-normal-Medium, 500);
+    line-height: var(--font-line-height-text-xs, 16px); /* 133.333% */
+}
+.video-audio-chat-container .action-minimize-audio-control .recording-video-info .recording-tooltip {
+    position: absolute;
+    top: -42px;
+    width: 180px;
+    left: -75px;
+    height: auto;
+    margin: 0 auto;
+    border-radius: var(--default, 8px);
+    background: var(--colors-background-bg-primary-solid, #0C111D);
+    padding: var(--default, 8px) var(--md, 12px);
+    color: var(--colors-text-text-white, #FFF);
+    text-align: center;
+    font-size: var(--font-size-text-xs, 12px);
+    font-weight: var(--font-weight-normal-Semibold, 600);
+    line-height: var(--font-line-height-text-xs, 16px);
+    opacity: 0;
+    visibility: hidden;
+}
+.video-audio-chat-container .action-minimize-audio-control .recording-video-info .recording-tooltip::before {
+    content: "";
+    position: absolute;
+    bottom: -5px;
+    width: 10px;
+    height: 10px;
+    background: var(--colors-background-bg-primary-solid, #0C111D);
+    left: 96px;
+    margin: 0 auto;
+    transform: rotate(45deg);
+}
+
+.video-audio-chat-container .action-minimize-audio-control .recording-video-info:hover .recording-tooltip {
+    opacity: 1;
+    visibility: visible;
+}
+
+.video-audio-chat-container .action-minimize-audio-control .recording-video-info svg{
+    flex-shrink: 0;
+}
+
+.video-audio-chat-container .action-minimize-audio-control .recording-video-info p{
+    color: var(--component-colors-utility-error-utility-error-700, #B42318);
+    text-align: center;
+    font-size: var(--font-size-text-xs, 12px);
+    font-weight: var(--font-weight-normal-Medium, 500);
+    line-height: var(--font-line-height-text-xs, 16px);
 }
 .video-audio-chat-container .action-minimize-audio-control .maximize-video {
     border-radius: 100%;

--- a/src/templatemanager/base/chatWidgetHeader/chatWidgetHeader.tsx
+++ b/src/templatemanager/base/chatWidgetHeader/chatWidgetHeader.tsx
@@ -4,7 +4,6 @@ import './chatWidgetHeader.scss';
 import { h } from 'preact';
 import { useState, useEffect } from 'preact/hooks';
 import IconsManager from '../iconsManager';
-import { openCustomSliderModal } from '../customSliderModal/customSliderModal';
 
 export function ChatWidgetHeader(props: any) {
     const hostInstance = props.hostInstance;
@@ -23,10 +22,6 @@ export function ChatWidgetHeader(props: any) {
     const handleHeaderIcon = (data: any) => {
         hostInstance.sendMessage(data);
     }
-
-    const openBottomSheetDemo = () => {
-        openCustomSliderModal(hostInstance, { variant: 'warning' });
-    };
 
     useEffect(() => {
         hostInstance.eventManager.removeEventListener('.btn-reconnect', 'click');
@@ -128,14 +123,6 @@ export function ChatWidgetHeader(props: any) {
                 </div>
             </div>
             <div className="actions-info">
-                <button title="Open bottom sheet (demo)" className="btn-action btn-open-bottom-sheet-demo" type="button" aria-label="Open bottom sheet demo" onClick={openBottomSheetDemo}>
-                    <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
-                        <path d="M3.75 5.625C3.75 4.93464 4.30964 4.375 5 4.375H7.5C8.19036 4.375 8.75 4.93464 8.75 5.625V8.125C8.75 8.81536 8.19036 9.375 7.5 9.375H5C4.30964 9.375 3.75 8.81536 3.75 8.125V5.625Z" stroke="#697586" strokeWidth="1.25" />
-                        <path d="M11.25 5.625C11.25 4.93464 11.8096 4.375 12.5 4.375H15C15.6904 4.375 16.25 4.93464 16.25 5.625V8.125C16.25 8.81536 15.6904 9.375 15 9.375H12.5C11.8096 9.375 11.25 8.81536 11.25 8.125V5.625Z" stroke="#697586" strokeWidth="1.25" />
-                        <path d="M3.75 13.125C3.75 12.4346 4.30964 11.875 5 11.875H7.5C8.19036 11.875 8.75 12.4346 8.75 13.125V15.625C8.75 16.3154 8.19036 16.875 7.5 16.875H5C4.30964 16.875 3.75 16.3154 3.75 15.625V13.125Z" stroke="#697586" strokeWidth="1.25" />
-                        <path d="M11.25 13.125C11.25 12.4346 11.8096 11.875 12.5 11.875H15C15.6904 11.875 16.25 12.4346 16.25 13.125V15.625C16.25 16.3154 15.6904 16.875 15 16.875H12.5C11.8096 16.875 11.25 16.3154 11.25 15.625V13.125Z" stroke="#697586" strokeWidth="1.25" />
-                    </svg>
-                </button>
                { brandingInfo.header.buttons.help.show && <a title={hostInstance.config.botMessages.help} href={brandingInfo.header.buttons.help.action.value} target="_blank" className="btn-action link-url">
                     {/* <figure>
                         <img src={iconHelper.getIcon('help')} alt="back button" />

--- a/src/templatemanager/base/chatWidgetHeader/chatWidgetHeader.tsx
+++ b/src/templatemanager/base/chatWidgetHeader/chatWidgetHeader.tsx
@@ -4,6 +4,7 @@ import './chatWidgetHeader.scss';
 import { h } from 'preact';
 import { useState, useEffect } from 'preact/hooks';
 import IconsManager from '../iconsManager';
+import { openCustomSliderModal } from '../customSliderModal/customSliderModal';
 
 export function ChatWidgetHeader(props: any) {
     const hostInstance = props.hostInstance;
@@ -22,6 +23,10 @@ export function ChatWidgetHeader(props: any) {
     const handleHeaderIcon = (data: any) => {
         hostInstance.sendMessage(data);
     }
+
+    const openBottomSheetDemo = () => {
+        openCustomSliderModal(hostInstance, { variant: 'warning' });
+    };
 
     useEffect(() => {
         hostInstance.eventManager.removeEventListener('.btn-reconnect', 'click');
@@ -123,6 +128,14 @@ export function ChatWidgetHeader(props: any) {
                 </div>
             </div>
             <div className="actions-info">
+                <button title="Open bottom sheet (demo)" className="btn-action btn-open-bottom-sheet-demo" type="button" aria-label="Open bottom sheet demo" onClick={openBottomSheetDemo}>
+                    <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+                        <path d="M3.75 5.625C3.75 4.93464 4.30964 4.375 5 4.375H7.5C8.19036 4.375 8.75 4.93464 8.75 5.625V8.125C8.75 8.81536 8.19036 9.375 7.5 9.375H5C4.30964 9.375 3.75 8.81536 3.75 8.125V5.625Z" stroke="#697586" strokeWidth="1.25" />
+                        <path d="M11.25 5.625C11.25 4.93464 11.8096 4.375 12.5 4.375H15C15.6904 4.375 16.25 4.93464 16.25 5.625V8.125C16.25 8.81536 15.6904 9.375 15 9.375H12.5C11.8096 9.375 11.25 8.81536 11.25 8.125V5.625Z" stroke="#697586" strokeWidth="1.25" />
+                        <path d="M3.75 13.125C3.75 12.4346 4.30964 11.875 5 11.875H7.5C8.19036 11.875 8.75 12.4346 8.75 13.125V15.625C8.75 16.3154 8.19036 16.875 7.5 16.875H5C4.30964 16.875 3.75 16.3154 3.75 15.625V13.125Z" stroke="#697586" strokeWidth="1.25" />
+                        <path d="M11.25 13.125C11.25 12.4346 11.8096 11.875 12.5 11.875H15C15.6904 11.875 16.25 12.4346 16.25 13.125V15.625C16.25 16.3154 15.6904 16.875 15 16.875H12.5C11.8096 16.875 11.25 16.3154 11.25 15.625V13.125Z" stroke="#697586" strokeWidth="1.25" />
+                    </svg>
+                </button>
                { brandingInfo.header.buttons.help.show && <a title={hostInstance.config.botMessages.help} href={brandingInfo.header.buttons.help.action.value} target="_blank" className="btn-action link-url">
                     {/* <figure>
                         <img src={iconHelper.getIcon('help')} alt="back button" />

--- a/src/templatemanager/base/customSliderModal/customSliderModal.scss
+++ b/src/templatemanager/base/customSliderModal/customSliderModal.scss
@@ -1,0 +1,70 @@
+.custom-slider-modal {
+    .custom-slider-modal__body {
+        padding: var(--xl, 24px) var(--xl, 24px) var(--default, 16px) var(--xl, 24px);
+    }
+
+    .custom-slider-modal__icon {
+        display: flex;
+        width: 48px;
+        height: 48px;
+        padding: 12px;
+        justify-content: center;
+        align-items: center;
+        border-radius: var(--full, 9999px);
+        margin-bottom: 16px;
+        color: var(--custom-slider-modal-icon-fg, #dc6803);
+        background: var(--custom-slider-modal-icon-bg, #fef0c7);
+    }
+
+    h1 {
+        color: var(--sdk-gloabl-text-color);
+        font-size: var(--font-size-text-lg, 18px);
+        font-weight: var(--font-weight-normal-Semibold, 600);
+        line-height: var(--font-line-height-text-lg, 28px);
+        margin-bottom: 4px;
+    }
+
+    p {
+        color: var(--sdk-gloabl-text-color);
+        font-size: var(--font-size-text-sm, 14px);
+        font-weight: var(--font-weight-normal-Regular, 400);
+        line-height: var(--font-line-height-text-sm, 20px);
+        opacity: 0.6;
+        margin: 0;
+    }
+
+    .custom-slider-modal__actions {
+        padding-top: 24px;
+        margin-top: 12px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        width: 100%;
+
+        .kr-button-primary,
+        .kr-button-secondary {
+            flex: 1 1 auto;
+            min-width: 0;
+        }
+    }
+
+    &--warning {
+        --custom-slider-modal-icon-bg: var(--colors-background-bg-warning-secondary, #fef0c7);
+        --custom-slider-modal-icon-fg: #dc6803;
+    }
+
+    &--error {
+        --custom-slider-modal-icon-bg: var(--colors-background-bg-error-secondary, #fee4e2);
+        --custom-slider-modal-icon-fg: #d92d20;
+    }
+
+    &--info {
+        --custom-slider-modal-icon-bg: var(--colors-background-bg-brand-secondary, rgba(75, 78, 222, 0.12));
+        --custom-slider-modal-icon-fg: var(--sdk-global-theme-color, #4b4ede);
+    }
+
+    &--success {
+        --custom-slider-modal-icon-bg: var(--colors-background-bg-success-secondary, #d1fadf);
+        --custom-slider-modal-icon-fg: #079455;
+    }
+}

--- a/src/templatemanager/base/customSliderModal/customSliderModal.tsx
+++ b/src/templatemanager/base/customSliderModal/customSliderModal.tsx
@@ -15,6 +15,8 @@ export interface CustomSliderModalOptions {
     secondaryLabel?: string;
     /** Default true. Set false for a single primary action. */
     showSecondaryButton?: boolean;
+    emitOnPrimary?: string;
+    emitOnSecondary?: string;
 }
 
 const defaultCopy: Record<
@@ -131,21 +133,15 @@ export function CustomSliderModal(props: any) {
     const close = () => closeBottomSlider(hostInstance);
 
     const proccedAction = () => {
-        const isRecordingConsentModal =
-            variant === 'warning' &&
-            title === defaultCopy.warning.title &&
-            primaryLabel === defaultCopy.warning.primaryLabel &&
-            secondaryLabel === defaultCopy.warning.secondaryLabel;
-
-        if (isRecordingConsentModal && typeof hostInstance?.emit === 'function') {
-            hostInstance.emit('video_call_recording_proceed');
+        if (opts.emitOnPrimary && typeof hostInstance?.emit === 'function') {
+            hostInstance.emit(opts.emitOnPrimary);
         }
         close();
     };
 
     const declineAction = () => {
-        if (typeof hostInstance?.emit === 'function') {
-            hostInstance.emit('video_call_recording_decline');
+        if (opts.emitOnSecondary && typeof hostInstance?.emit === 'function') {
+            hostInstance.emit(opts.emitOnSecondary);
         }
         close();
     };

--- a/src/templatemanager/base/customSliderModal/customSliderModal.tsx
+++ b/src/templatemanager/base/customSliderModal/customSliderModal.tsx
@@ -1,0 +1,163 @@
+import '../menu/menu.scss';
+import './customSliderModal.scss';
+import { h } from 'preact';
+import { getHTML } from '../domManager';
+
+/** Popup style: warning, error, info, success. Extend the union and `defaultCopy` when adding a state. */
+export type CustomSliderModalVariant = 'warning' | 'error' | 'info' | 'success';
+
+export interface CustomSliderModalOptions {
+    variant?: CustomSliderModalVariant;
+    title?: string;
+    body?: string;
+    primaryLabel?: string;
+    secondaryLabel?: string;
+    /** Default true. Set false for a single primary action. */
+    showSecondaryButton?: boolean;
+}
+
+const defaultCopy: Record<
+    CustomSliderModalVariant,
+    { title: string; body: string; primaryLabel: string; secondaryLabel: string }
+> = {
+    warning: {
+        title: 'Recording started',
+        body: 'This video call will now be recorded to help improve our services. Please do not share sensitive information like passwords or OTPs. If you are not comfortable with recording, let the agent know or you may end the call.',
+        primaryLabel: 'Proceed',
+        secondaryLabel: 'Decline',
+    },
+    error: {
+        title: 'Something went wrong',
+        body: 'We could not complete this action. Please try again or contact support if the problem continues.',
+        primaryLabel: 'Try again',
+        secondaryLabel: 'Dismiss',
+    },
+    info: {
+        title: 'Heads up',
+        body: 'Here is some information you should know before continuing.',
+        primaryLabel: 'Continue',
+        secondaryLabel: 'Cancel',
+    },
+    success: {
+        title: 'Done',
+        body: 'Your action completed successfully.',
+        primaryLabel: 'OK',
+        secondaryLabel: 'Close',
+    },
+};
+
+function closeBottomSlider(hostInstance: any) {
+    const wrap = hostInstance.chatEle.querySelector('.chat-actions-bottom-wraper');
+    if (!wrap) {
+        return;
+    }
+    wrap.classList.add('close-bottom-slide');
+    setTimeout(() => {
+        wrap.remove();
+    }, 150);
+}
+
+function IconForVariant(props: { variant: CustomSliderModalVariant }) {
+    const { variant } = props;
+    if (variant === 'warning') {
+        return (
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path
+                    d="M11.9998 8.99999V13M11.9998 17H12.0098M10.6151 3.89171L2.39019 18.0983C1.93398 18.8863 1.70588 19.2803 1.73959 19.6037C1.769 19.8857 1.91677 20.142 2.14613 20.3088C2.40908 20.5 2.86435 20.5 3.77487 20.5H20.2246C21.1352 20.5 21.5904 20.5 21.8534 20.3088C22.0827 20.142 22.2305 19.8857 22.2599 19.6037C22.2936 19.2803 22.0655 18.8863 21.6093 18.0983L13.3844 3.89171C12.9299 3.10654 12.7026 2.71396 12.4061 2.58211C12.1474 2.4671 11.8521 2.4671 11.5935 2.58211C11.2969 2.71396 11.0696 3.10655 10.6151 3.89171Z"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                />
+            </svg>
+        );
+    }
+    if (variant === 'error') {
+        return (
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path
+                    d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                />
+                <path d="M15 9L9 15M9 9L15 15" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+        );
+    }
+    if (variant === 'info') {
+        return (
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path
+                    d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                />
+                <path d="M12 16V12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                <path d="M12 8H12.01" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+        );
+    }
+    return (
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path
+                d="M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+            <path d="M8 12.5L11 15.5L16 9.5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+    );
+}
+
+/** Custom bottom-slider modal: warning-style popup (and error / info / success variants). */
+export function CustomSliderModal(props: any) {
+    const hostInstance = props.hostInstance;
+    const opts: CustomSliderModalOptions = props.msgData && typeof props.msgData === 'object' ? props.msgData : {};
+    const variant: CustomSliderModalVariant = opts.variant && defaultCopy[opts.variant] ? opts.variant : 'warning';
+    const defaults = defaultCopy[variant];
+    const title = opts.title ?? defaults.title;
+    const body = opts.body ?? defaults.body;
+    const primaryLabel = opts.primaryLabel ?? defaults.primaryLabel;
+    const secondaryLabel = opts.secondaryLabel ?? defaults.secondaryLabel;
+    const showSecondary = opts.showSecondaryButton !== false;
+
+    const close = () => closeBottomSlider(hostInstance);
+
+    return (
+        <div
+            className={`menu-wrapper-data-actions custom-slider-modal custom-slider-modal--${variant}`}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="custom-slider-modal-title"
+        >
+            <div className="iner-data-scroll-wraper custom-slider-modal__body">
+                <div className="custom-slider-modal__icon" aria-hidden="true">
+                    <IconForVariant variant={variant} />
+                </div>
+                <h1 id="custom-slider-modal-title">{title}</h1>
+                <p>{body}</p>
+                <div className="custom-slider-modal__actions">
+                    {showSecondary && (
+                        <button className="kr-button-secondary lg" type="button" onClick={close}>
+                            {secondaryLabel}
+                        </button>
+                    )}
+                    <button className="kr-button-primary lg" type="button" onClick={close}>
+                        {primaryLabel}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+/** Opens the bottom slider with {@link CustomSliderModal} content. */
+export function openCustomSliderModal(hostInstance: any, options?: CustomSliderModalOptions) {
+    hostInstance.bottomSliderAction('', getHTML(CustomSliderModal, options ?? {}, hostInstance));
+}

--- a/src/templatemanager/base/customSliderModal/customSliderModal.tsx
+++ b/src/templatemanager/base/customSliderModal/customSliderModal.tsx
@@ -1,3 +1,4 @@
+/** @jsx h */
 import '../menu/menu.scss';
 import './customSliderModal.scss';
 import { h } from 'preact';
@@ -129,6 +130,26 @@ export function CustomSliderModal(props: any) {
 
     const close = () => closeBottomSlider(hostInstance);
 
+    const proccedAction = () => {
+        const isRecordingConsentModal =
+            variant === 'warning' &&
+            title === defaultCopy.warning.title &&
+            primaryLabel === defaultCopy.warning.primaryLabel &&
+            secondaryLabel === defaultCopy.warning.secondaryLabel;
+
+        if (isRecordingConsentModal && typeof hostInstance?.emit === 'function') {
+            hostInstance.emit('video_call_recording_proceed');
+        }
+        close();
+    };
+
+    const declineAction = () => {
+        if (typeof hostInstance?.emit === 'function') {
+            hostInstance.emit('video_call_recording_decline');
+        }
+        close();
+    };
+
     return (
         <div
             className={`menu-wrapper-data-actions custom-slider-modal custom-slider-modal--${variant}`}
@@ -144,11 +165,11 @@ export function CustomSliderModal(props: any) {
                 <p>{body}</p>
                 <div className="custom-slider-modal__actions">
                     {showSecondary && (
-                        <button className="kr-button-secondary lg" type="button" onClick={close}>
+                        <button className="kr-button-secondary lg" type="button" onClick={declineAction}>
                             {secondaryLabel}
                         </button>
                     )}
-                    <button className="kr-button-primary lg" type="button" onClick={close}>
+                    <button className="kr-button-primary lg" type="button" onClick={proccedAction}>
                         {primaryLabel}
                     </button>
                 </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new event-driven UI and bot messaging around video call recording, plus injects SIP headers for video calls; mistakes could lead to incorrect consent handling or recording state display during calls.
> 
> **Overview**
> Adds **video-call recording consent and status support** to the Agent Desktop WebRTC flow.
> 
> The plugin now reacts to new `video_call_recording_*` events by opening a bottom-slider consent modal (Proceed/Decline), emitting acceptance/decline messages back to the bot, auto-closing on timeout, and tracking/reflecting recording paused/resumed state via a new inline “Rec/Rec Paused” indicator in the video call controls. Video call SIP initiation is also updated to include bot/conversation metadata headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46cb1af2ec542baac72cd4ece6157ecbda71f14a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->