### PR TITLE
PLAT-38865 - Prototype Pollution - Code fix

### DIFF
--- a/src/plugins/agentDesktop/agentdesktop-script.js
+++ b/src/plugins/agentDesktop/agentdesktop-script.js
@@ -8340,6 +8340,8 @@ rrwebInit = function (exports) {
             var _this = this;
             var _a, _b;
             var d = e.data;
+            if (!d || typeof d !== 'object') return;
+            if (Object.prototype.hasOwnProperty.call(d, '__proto__') || Object.prototype.hasOwnProperty.call(d, 'constructor') || Object.prototype.hasOwnProperty.call(d, 'prototype')) return;
             switch (d.source) {
                 case exports.IncrementalSource.Mutation: {
                     if (isSync) {
@@ -8671,6 +8673,8 @@ rrwebInit = function (exports) {
         Replayer.prototype.applyMutation = function (d, useVirtualParent) {
             var e_11, _a;
             var _this = this;
+            if (!d || typeof d !== 'object') return;
+            if (Object.prototype.hasOwnProperty.call(d, '__proto__') || Object.prototype.hasOwnProperty.call(d, 'constructor') || Object.prototype.hasOwnProperty.call(d, 'prototype')) return;
             d.removes.forEach(function (mutation) {
                 var target = _this.mirror.getNode(mutation.id);
                 if (!target) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds early-return validation in replay event handlers, which could drop malformed or unexpected incremental events and slightly alter session replay behavior while mitigating a security issue.
> 
> **Overview**
> Adds defensive checks in `Replayer.applyIncremental` and `Replayer.applyMutation` to **ignore non-object event payloads** and **reject payloads containing `__proto__`, `constructor`, or `prototype` keys**, preventing prototype-pollution vectors during session replay mutation processing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 052ada88841d5394b3d2b6d5c07c6a57661ce89c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->