### PR TITLE
 XOP-30265 - feat(secureChannel): browser-side ECDH+AES-GCM  client for duplex encryption

### DIFF
--- a/docs/configurations/koreconfig/README.md
+++ b/docs/configurations/koreconfig/README.md
@@ -75,6 +75,20 @@ botOptions.webhookConfig = {
 
 **Note:** Polling must be enabled for webhook version 2. Refer to the [documentation](https://docs.kore.ai/xo/channels/add-webhook-channel/#step-1-associate-an-app) for polling setup.
 
+### Secure duplex communication
+```typescript
+botOptions.secureChannel = {
+    pinnedPublicKeyPem: [
+      '-----BEGIN PUBLIC KEY-----',
+      'xxxxxxxxxxxxxxxxxxxxx',
+      '-----END PUBLIC KEY-----'
+    ].join('\n'),
+    expectedSigningKeyId: 'kid-default'
+  };
+```
+
+For secure duplex communication we must pass public key and signing key
+
 ## UI and Interaction Settings
 
 ### Chat Window Configuration

--- a/src/components/base-sdk/kore-bot-sdk-client.js
+++ b/src/components/base-sdk/kore-bot-sdk-client.js
@@ -1529,8 +1529,7 @@ let requireKr=(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeo
       var rtmClient = this;
       this.secureChannel = clientOpts.secureChannelFactory({
         config: { pinnedPublicKeyPem: secureChannelConfig.pinnedPublicKeyPem, expectedSigningKeyId: secureChannelConfig.expectedSigningKeyId },
-        rawSend: function (frame) { return rtmClient.rawSend(frame); },
-        logger: debug
+        rawSend: function (frame) { return rtmClient.rawSend(frame); }
       });
     }
   }

--- a/src/components/base-sdk/kore-bot-sdk-client.js
+++ b/src/components/base-sdk/kore-bot-sdk-client.js
@@ -1524,11 +1524,11 @@ let requireKr=(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeo
     };
     this.enableSecureRTM = clientOpts.enableSecureRTM !== false
     this.secureChannel = null;
-    var scCfg = clientOpts.secureChannel;
-    if (scCfg && scCfg.pinnedPublicKeyPem && typeof clientOpts.secureChannelFactory === 'function') {
+    var secureChannelConfig = clientOpts.secureChannel;
+    if (secureChannelConfig && secureChannelConfig.pinnedPublicKeyPem && typeof clientOpts.secureChannelFactory === 'function') {
       var rtmClient = this;
       this.secureChannel = clientOpts.secureChannelFactory({
-        config: { pinnedPublicKeyPem: scCfg.pinnedPublicKeyPem, expectedSigningKeyId: scCfg.expectedSigningKeyId },
+        config: { pinnedPublicKeyPem: secureChannelConfig.pinnedPublicKeyPem, expectedSigningKeyId: secureChannelConfig.expectedSigningKeyId },
         rawSend: function (frame) { return rtmClient.rawSend(frame); },
         logger: debug
       });

--- a/src/components/base-sdk/kore-bot-sdk-client.js
+++ b/src/components/base-sdk/kore-bot-sdk-client.js
@@ -1746,15 +1746,35 @@ let requireKr=(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeo
   
   
   KoreRTMClient.prototype.handleWsMessage = function handleWsMessage(wsMsg) {
+    var _this = this;
     var message;
-    this.emit("message", wsMsg);
-  
+
     try {
       message = JSON.parse(wsMsg);
     } catch (err) {
+      // Non-JSON frame — preserve legacy raw emit and stop.
+      this.emit("message", wsMsg);
       return;
     }
-  
+
+    // Decryption chokepoint. Consume handshake/rekey frames here, and decrypt
+    // secure_envelopes ONCE so the plaintext reaches EVERY listener (chatWindow,
+    // agentDesktop, delivery-ack logic) rather than only chatWindow's listener.
+    if (this._secureChannel && this._secureChannel.isRelevant(message)) {
+      this._secureChannel.processIncoming(message).then(function (res) {
+        if (!res || res.handled) return;               // protocol frame consumed
+        var out = (res.plaintext !== undefined) ? res.plaintext : message;
+        _this.emit("message", JSON.stringify(out));
+        _this._routeParsedMessage(out);
+      }).catch(function () { /* fail-open: drop this frame, never crash the socket */ });
+      return;
+    }
+
+    this.emit("message", wsMsg);
+    this._routeParsedMessage(message);
+  };
+
+  KoreRTMClient.prototype._routeParsedMessage = function _routeParsedMessage(message) {
     if (contains(RTM_CLIENT_INTERNAL_EVENT_TYPES, message.type)) {
       this._handleWsMessageInternal(message.type, message);
     } else {
@@ -1801,8 +1821,12 @@ let requireKr=(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeo
   
   KoreRTMClient.prototype.handleWsClose = function handleWsClose(code, reason) {
     this.connected = false;
+    // The secure channel's keys belong to this socket session. Drop them so the
+    // next connection performs a fresh handshake instead of encrypting with the
+    // dead session's keys (which the server can no longer decrypt).
+    if (this._secureChannel) { this._secureChannel.reset('ws_close'); }
     this.emit(CLIENT_EVENTS.WS_CLOSE, code, reason);
-  
+
     if (this.autoReconnect) {
       if (!this._connecting) {
         this.reconnect();
@@ -1827,22 +1851,43 @@ let requireKr=(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeo
   KoreRTMClient.prototype.sendMessage = function sendMessage(message, optCb) {
     this.send(message, optCb);
   };
-  
+
+  // Encryption chokepoint. If a secure channel is attached and engaged, the
+  // fully-enriched frame is encrypted here before the raw write, so user
+  // messages, delivery acks and plugin sends are all covered uniformly.
+  // Handshake/pre-secure traffic passes through unchanged. Fail-closed: on an
+  // encrypt error we surface it via optCb and never fall back to plaintext.
   KoreRTMClient.prototype.send = function send(message, optCb) {
+    var _this = this;
+    if (this._secureChannel) {
+      Promise.resolve(this._secureChannel.processOutgoing(message)).then(function (frameToSend) {
+        _this._rawSend(frameToSend, optCb);
+      }, function (sendErr) {
+        if (!isUndefined(optCb)) {
+          optCb(sendErr instanceof Error ? sendErr : new Error(String((sendErr && sendErr.message) || sendErr)));
+        }
+      });
+      return;
+    }
+    this._rawSend(message, optCb);
+  };
+
+  // Raw write to the socket (id-stamp + stringify + ws.send). This is the
+  // plaintext path the secure channel uses for handshake/rekey frames.
+  KoreRTMClient.prototype._rawSend = function _rawSend(message, optCb) {
     var wsMsg = cloneDeep(message);
     var jsonMessage;
     var err;
-    var _this = this;
-  
+
     if (this.connected && !this._reconnecting) {
       wsMsg.id = wsMsg.clientMessageId || this.nextMessageId();
       jsonMessage = JSON.stringify(wsMsg);
-  
+
       this._pendingMessages[wsMsg.id] = wsMsg;
       this.ws.send(jsonMessage, undefined, function handleWsMsgResponse(wsRespErr) {
         if (!isUndefined(wsRespErr)) {
         }
-  
+
         if (!isUndefined(optCb)) {
           optCb(wsRespErr);
         }

--- a/src/components/base-sdk/kore-bot-sdk-client.js
+++ b/src/components/base-sdk/kore-bot-sdk-client.js
@@ -1758,32 +1758,30 @@ let requireKr=(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeo
   
   KoreRTMClient.prototype.handleWsMessage = function handleWsMessage(wsMsg) {
     var _this = this;
-    var message;
 
+    // Decryption chokepoint: browser WS delivers a MessageEvent, so parse .data (JSON.parse(wsMsg) fails on the event) to consume handshake/rekey frames and decrypt envelopes before any listener.
+    if (this._secureChannel) {
+      var rawData = (wsMsg && typeof wsMsg.data === 'string') ? wsMsg.data
+        : (typeof wsMsg === 'string' ? wsMsg : null);
+      var parsed = null;
+      if (rawData) { try { parsed = JSON.parse(rawData); } catch (e) { parsed = null; } }
+      if (parsed && this._secureChannel.isRelevant(parsed)) {
+        this._secureChannel.processIncoming(parsed).then(function (res) {
+          if (!res || res.handled) return;
+          var out = (res.plaintext !== undefined) ? res.plaintext : parsed;
+          _this.emit("message", { data: JSON.stringify(out) });
+        }).catch(function () {});
+        return;
+      }
+    }
+
+    var message;
+    this.emit("message", wsMsg);
     try {
       message = JSON.parse(wsMsg);
     } catch (err) {
-      // Non-JSON frame — preserve legacy raw emit and stop.
-      this.emit("message", wsMsg);
       return;
     }
-
-    // Decryption chokepoint: consume handshake/rekey frames, decrypt envelopes once for all listeners.
-    if (this._secureChannel && this._secureChannel.isRelevant(message)) {
-      this._secureChannel.processIncoming(message).then(function (res) {
-        if (!res || res.handled) return;
-        var out = (res.plaintext !== undefined) ? res.plaintext : message;
-        _this.emit("message", JSON.stringify(out));
-        _this._routeParsedMessage(out);
-      }).catch(function () {});
-      return;
-    }
-
-    this.emit("message", wsMsg);
-    this._routeParsedMessage(message);
-  };
-
-  KoreRTMClient.prototype._routeParsedMessage = function _routeParsedMessage(message) {
     if (contains(RTM_CLIENT_INTERNAL_EVENT_TYPES, message.type)) {
       this._handleWsMessageInternal(message.type, message);
     } else {

--- a/src/components/base-sdk/kore-bot-sdk-client.js
+++ b/src/components/base-sdk/kore-bot-sdk-client.js
@@ -1523,8 +1523,19 @@ let requireKr=(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeo
       factor: 2
     };
     this.enableSecureRTM = clientOpts.enableSecureRTM !== false
+    // Secure channel: built from the injected factory when the app requires encryption.
+    this._secureChannel = null;
+    var _scCfg = clientOpts.secureChannel;
+    if (_scCfg && _scCfg.pinnedPublicKeyPem && typeof clientOpts.secureChannelFactory === 'function') {
+      var _scRtm = this;
+      this._secureChannel = clientOpts.secureChannelFactory({
+        config: { pinnedPublicKeyPem: _scCfg.pinnedPublicKeyPem, expectedSigningKeyId: _scCfg.expectedSigningKeyId },
+        rawSend: function (frame) { return _scRtm._rawSend(frame); },
+        logger: debug
+      });
+    }
   }
-  
+
   inherits(KoreRTMClient, BaseAPIClient);
   
   
@@ -1757,16 +1768,14 @@ let requireKr=(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeo
       return;
     }
 
-    // Decryption chokepoint. Consume handshake/rekey frames here, and decrypt
-    // secure_envelopes ONCE so the plaintext reaches EVERY listener (chatWindow,
-    // agentDesktop, delivery-ack logic) rather than only chatWindow's listener.
+    // Decryption chokepoint: consume handshake/rekey frames, decrypt envelopes once for all listeners.
     if (this._secureChannel && this._secureChannel.isRelevant(message)) {
       this._secureChannel.processIncoming(message).then(function (res) {
-        if (!res || res.handled) return;               // protocol frame consumed
+        if (!res || res.handled) return;
         var out = (res.plaintext !== undefined) ? res.plaintext : message;
         _this.emit("message", JSON.stringify(out));
         _this._routeParsedMessage(out);
-      }).catch(function () { /* fail-open: drop this frame, never crash the socket */ });
+      }).catch(function () {});
       return;
     }
 
@@ -1821,9 +1830,7 @@ let requireKr=(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeo
   
   KoreRTMClient.prototype.handleWsClose = function handleWsClose(code, reason) {
     this.connected = false;
-    // The secure channel's keys belong to this socket session. Drop them so the
-    // next connection performs a fresh handshake instead of encrypting with the
-    // dead session's keys (which the server can no longer decrypt).
+    // Drop the secure channel so reconnect re-handshakes with fresh keys.
     if (this._secureChannel) { this._secureChannel.reset('ws_close'); }
     this.emit(CLIENT_EVENTS.WS_CLOSE, code, reason);
 
@@ -1852,11 +1859,7 @@ let requireKr=(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeo
     this.send(message, optCb);
   };
 
-  // Encryption chokepoint. If a secure channel is attached and engaged, the
-  // fully-enriched frame is encrypted here before the raw write, so user
-  // messages, delivery acks and plugin sends are all covered uniformly.
-  // Handshake/pre-secure traffic passes through unchanged. Fail-closed: on an
-  // encrypt error we surface it via optCb and never fall back to plaintext.
+  // Encryption chokepoint: encrypt when secure (fail-closed), else raw-send.
   KoreRTMClient.prototype.send = function send(message, optCb) {
     var _this = this;
     if (this._secureChannel) {
@@ -1872,8 +1875,7 @@ let requireKr=(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeo
     this._rawSend(message, optCb);
   };
 
-  // Raw write to the socket (id-stamp + stringify + ws.send). This is the
-  // plaintext path the secure channel uses for handshake/rekey frames.
+  // Raw write to the socket; also the plaintext path for handshake/rekey frames.
   KoreRTMClient.prototype._rawSend = function _rawSend(message, optCb) {
     var wsMsg = cloneDeep(message);
     var jsonMessage;

--- a/src/components/base-sdk/kore-bot-sdk-client.js
+++ b/src/components/base-sdk/kore-bot-sdk-client.js
@@ -1757,7 +1757,7 @@ let requireKr=(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeo
   KoreRTMClient.prototype.handleWsMessage = function handleWsMessage(wsMsg) {
     var _this = this;
 
-    // Browser WS payload is in wsMsg.data; decrypt/consume secure-channel frames before routing.
+    // decrypt secure-channel frames before emitting
     if (this.secureChannel) {
       var rawData = (wsMsg && typeof wsMsg.data === 'string') ? wsMsg.data
         : (typeof wsMsg === 'string' ? wsMsg : null);
@@ -1775,11 +1775,13 @@ let requireKr=(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeo
 
     var message;
     this.emit("message", wsMsg);
+
     try {
       message = JSON.parse(wsMsg);
     } catch (err) {
       return;
     }
+
     if (contains(RTM_CLIENT_INTERNAL_EVENT_TYPES, message.type)) {
       this._handleWsMessageInternal(message.type, message);
     } else {
@@ -1826,7 +1828,6 @@ let requireKr=(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeo
   
   KoreRTMClient.prototype.handleWsClose = function handleWsClose(code, reason) {
     this.connected = false;
-    // Drop the secure channel so reconnect re-handshakes with fresh keys.
     if (this.secureChannel) { this.secureChannel.reset('ws_close'); }
     this.emit(CLIENT_EVENTS.WS_CLOSE, code, reason);
 

--- a/src/components/base-sdk/kore-bot-sdk-client.js
+++ b/src/components/base-sdk/kore-bot-sdk-client.js
@@ -1523,14 +1523,13 @@ let requireKr=(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeo
       factor: 2
     };
     this.enableSecureRTM = clientOpts.enableSecureRTM !== false
-    // Secure channel: built from the injected factory when the app requires encryption.
-    this._secureChannel = null;
-    var _scCfg = clientOpts.secureChannel;
-    if (_scCfg && _scCfg.pinnedPublicKeyPem && typeof clientOpts.secureChannelFactory === 'function') {
-      var _scRtm = this;
-      this._secureChannel = clientOpts.secureChannelFactory({
-        config: { pinnedPublicKeyPem: _scCfg.pinnedPublicKeyPem, expectedSigningKeyId: _scCfg.expectedSigningKeyId },
-        rawSend: function (frame) { return _scRtm._rawSend(frame); },
+    this.secureChannel = null;
+    var scCfg = clientOpts.secureChannel;
+    if (scCfg && scCfg.pinnedPublicKeyPem && typeof clientOpts.secureChannelFactory === 'function') {
+      var rtmClient = this;
+      this.secureChannel = clientOpts.secureChannelFactory({
+        config: { pinnedPublicKeyPem: scCfg.pinnedPublicKeyPem, expectedSigningKeyId: scCfg.expectedSigningKeyId },
+        rawSend: function (frame) { return rtmClient.rawSend(frame); },
         logger: debug
       });
     }
@@ -1759,14 +1758,14 @@ let requireKr=(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeo
   KoreRTMClient.prototype.handleWsMessage = function handleWsMessage(wsMsg) {
     var _this = this;
 
-    // Decryption chokepoint: browser WS delivers a MessageEvent, so parse .data (JSON.parse(wsMsg) fails on the event) to consume handshake/rekey frames and decrypt envelopes before any listener.
-    if (this._secureChannel) {
+    // Browser WS payload is in wsMsg.data; decrypt/consume secure-channel frames before routing.
+    if (this.secureChannel) {
       var rawData = (wsMsg && typeof wsMsg.data === 'string') ? wsMsg.data
         : (typeof wsMsg === 'string' ? wsMsg : null);
       var parsed = null;
       if (rawData) { try { parsed = JSON.parse(rawData); } catch (e) { parsed = null; } }
-      if (parsed && this._secureChannel.isRelevant(parsed)) {
-        this._secureChannel.processIncoming(parsed).then(function (res) {
+      if (parsed && this.secureChannel.isRelevant(parsed)) {
+        this.secureChannel.processIncoming(parsed).then(function (res) {
           if (!res || res.handled) return;
           var out = (res.plaintext !== undefined) ? res.plaintext : parsed;
           _this.emit("message", { data: JSON.stringify(out) });
@@ -1829,7 +1828,7 @@ let requireKr=(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeo
   KoreRTMClient.prototype.handleWsClose = function handleWsClose(code, reason) {
     this.connected = false;
     // Drop the secure channel so reconnect re-handshakes with fresh keys.
-    if (this._secureChannel) { this._secureChannel.reset('ws_close'); }
+    if (this.secureChannel) { this.secureChannel.reset('ws_close'); }
     this.emit(CLIENT_EVENTS.WS_CLOSE, code, reason);
 
     if (this.autoReconnect) {
@@ -1857,12 +1856,11 @@ let requireKr=(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeo
     this.send(message, optCb);
   };
 
-  // Encryption chokepoint: encrypt when secure (fail-closed), else raw-send.
   KoreRTMClient.prototype.send = function send(message, optCb) {
     var _this = this;
-    if (this._secureChannel) {
-      Promise.resolve(this._secureChannel.processOutgoing(message)).then(function (frameToSend) {
-        _this._rawSend(frameToSend, optCb);
+    if (this.secureChannel) {
+      Promise.resolve(this.secureChannel.processOutgoing(message)).then(function (frameToSend) {
+        _this.rawSend(frameToSend, optCb);
       }, function (sendErr) {
         if (!isUndefined(optCb)) {
           optCb(sendErr instanceof Error ? sendErr : new Error(String((sendErr && sendErr.message) || sendErr)));
@@ -1870,11 +1868,10 @@ let requireKr=(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeo
       });
       return;
     }
-    this._rawSend(message, optCb);
+    this.rawSend(message, optCb);
   };
 
-  // Raw write to the socket; also the plaintext path for handshake/rekey frames.
-  KoreRTMClient.prototype._rawSend = function _rawSend(message, optCb) {
+  KoreRTMClient.prototype.rawSend = function rawSend(message, optCb) {
     var wsMsg = cloneDeep(message);
     var jsonMessage;
     var err;

--- a/src/components/chatwindow/chatWindow.ts
+++ b/src/components/chatwindow/chatWindow.ts
@@ -1354,10 +1354,26 @@ async _handleSecureChannelFrame (msg: any) {
         pinnedPublicKeyPem,
         expectedSigningKeyId: sc && sc.expectedSigningKeyId,
       } as any);
+      // Arm a handshake timeout: if the server never completes the
+      // 4-step exchange (network issue, server bug, attacker stalling),
+      // tear down the channel state so the next `protocol_capabilities`
+      // can re-initiate cleanly instead of being rejected as
+      // handshake_state_invalid.
+      const HANDSHAKE_TIMEOUT_MS = 10_000;
+      me._secureChannelHandshakeTimer = setTimeout(() => {
+        if (me._secureChannel && !me._secureChannel.isSecure()) {
+          console.error('[secureChannel] handshake timeout — resetting');
+          me._resetSecureChannel();
+        }
+      }, HANDSHAKE_TIMEOUT_MS);
       const init = await me._secureChannel.initiateHandshake();
-      me.bot.sendMessage(init);
+      try { me.bot.sendMessage(init); } catch (sendErr) {
+        console.error('[secureChannel] failed to send key_exchange_init:', sendErr);
+        me._resetSecureChannel();
+      }
     } catch (e) {
       console.error('[secureChannel] init failed:', e);
+      me._resetSecureChannel();
     }
     return { consumed: true };
   }
@@ -1366,9 +1382,13 @@ async _handleSecureChannelFrame (msg: any) {
   if (msg.type === 'key_exchange_response' && me._secureChannel) {
     try {
       const complete = await me._secureChannel.handleResponse(msg);
-      me.bot.sendMessage(complete);
+      try { me.bot.sendMessage(complete); } catch (sendErr) {
+        console.error('[secureChannel] failed to send key_exchange_complete:', sendErr);
+        me._resetSecureChannel();
+      }
     } catch (e) {
       console.error('[secureChannel] response handling failed:', e);
+      me._resetSecureChannel();
     }
     return { consumed: true };
   }
@@ -1377,11 +1397,16 @@ async _handleSecureChannelFrame (msg: any) {
   if (msg.type === 'key_exchange_ack' && me._secureChannel) {
     try {
       await me._secureChannel.handleAck(msg);
+      if (me._secureChannelHandshakeTimer) {
+        clearTimeout(me._secureChannelHandshakeTimer);
+        me._secureChannelHandshakeTimer = null;
+      }
       console.log('[secureChannel] channel SECURE');
       // Wrap outgoing sendMessage exactly once now that we're secure.
       me._wrapBotSendMessageForEncryption();
     } catch (e) {
       console.error('[secureChannel] ack handling failed:', e);
+      me._resetSecureChannel();
     }
     return { consumed: true };
   }
@@ -1389,7 +1414,15 @@ async _handleSecureChannelFrame (msg: any) {
   // Encrypted message envelope — decrypt and pass through as plaintext.
   if (msg.type === 'secure_envelope' && me._secureChannel && me._secureChannel.isSecure()) {
     try {
-      const plain = await me._secureChannel.decryptIncoming(msg);
+      const plain: any = await me._secureChannel.decryptIncoming(msg);
+      // Decrypted __control frames (e.g. rekey_signal) are protocol
+      // metadata, not user messages. They must not be rendered.
+      if (plain && plain.__control === true) {
+        // Reserved for future client-handled control frames (rekey_ack,
+        // session_invalidate, etc.). Today the server initiates rekey
+        // via its own handler; nothing to do client-side.
+        return { consumed: true };
+      }
       return { consumed: false, decrypted: plain };
     } catch (e) {
       console.error('[secureChannel] decrypt failed:', e);
@@ -1400,10 +1433,34 @@ async _handleSecureChannelFrame (msg: any) {
   return { consumed: false };
 }
 
+// Tear down secure-channel state and restore plaintext sendMessage.
+// Called on handshake failure, handshake timeout, and WS close — these
+// are the points where leaving the wrapped sendMessage in place would
+// either drop user messages (channel_not_secure) or wrap them with a
+// key the server has already discarded.
+_resetSecureChannel () {
+  const me: any = this;
+  if (me._secureChannelHandshakeTimer) {
+    clearTimeout(me._secureChannelHandshakeTimer);
+    me._secureChannelHandshakeTimer = null;
+  }
+  if (me._botSendMessageOriginal) {
+    me.bot.sendMessage = me._botSendMessageOriginal;
+    me._botSendMessageOriginal = null;
+  }
+  me._botSendMessageWrapped = false;
+  me._secureChannel = null;
+}
+
 _wrapBotSendMessageForEncryption () {
   const me: any = this;
   if (me._botSendMessageWrapped) return;
   const original = me.bot.sendMessage.bind(me.bot);
+  // Stash the original so _resetSecureChannel can restore the plaintext
+  // path on WS close / handshake failure. Without this, a reconnect
+  // would keep the wrapper bound to a dead manager and silently drop
+  // every outbound message.
+  me._botSendMessageOriginal = me.bot.sendMessage;
   me.bot.sendMessage = (messageToBot: any, callback?: any) => {
     if (me._secureChannel && me._secureChannel.isSecure()
         && messageToBot && messageToBot.type !== 'key_exchange_init'
@@ -1441,6 +1498,11 @@ bindSDKEvents  () {
   });
 
   me.bot.on('message', async (response: { data: string; }) => {
+    // Outer try/catch: this is an async event handler. Any uncaught
+    // rejection here becomes an unhandledrejection on the page, which
+    // some host applications surface to users as a generic error. Keep
+    // the WS event stream alive even if a single frame is malformed.
+    try {
     // actual implementation starts here
     if (me.popupOpened === true) {
       $('.kore-auth-popup .close-popup').trigger('click');
@@ -1498,6 +1560,16 @@ bindSDKEvents  () {
       }
       me.chatEle.setAttribute('dir', langDetails?.language == 'ar' || langDetails?.newLanguage == 'ar' ? 'rtl' : 'ltr');
     }
+    } catch (handlerErr) {
+      console.error('[chatWindow] ws message handler error:', handlerErr);
+    }
+  });
+
+  me.bot.on('close', () => {
+    // WS closed — any subsequent reconnect needs a fresh handshake.
+    // Reset secure-channel state and unwrap sendMessage so plaintext
+    // messages are not encrypted against stale, server-discarded keys.
+    me._resetSecureChannel();
   });
 
   me.bot.on('webhook_ready', (response: any) => {

--- a/src/components/chatwindow/chatWindow.ts
+++ b/src/components/chatwindow/chatWindow.ts
@@ -10,6 +10,8 @@ import './sass/chatWindow.scss';
 import './sass/fonts.scss';
 //import './../../libs/emojione.sprites.css';
 import chatConfig from './config/kore-config';
+// @ts-ignore — plain JS module
+import SecureChannel from '../secureChannel/secureChannel.js';
 //import GreeetingsPlugin from '../../plugins/greetings/greetings-plugin'
 
 // import welcomeScreeContainer from '../../preact/templates/base/welcomeScreeContainer/welcomeScreeContainer';
@@ -1329,6 +1331,102 @@ sendWebhookOnConnectEvent  () {
   });
 };
 
+// ─────────────────────────────────────────────────────────────────────
+// Secure channel — handshake / decrypt / encrypt hooks.
+// Activated only when the server sends a `protocol_capabilities`
+// message with encryption: 'required' (because the SDK app has the
+// duplexEncryptionEnabled flag set).
+// ─────────────────────────────────────────────────────────────────────
+async _handleSecureChannelFrame (msg: any) {
+  const me: any = this;
+  if (!msg || typeof msg !== 'object') return { consumed: false };
+
+  // Server announces it requires encryption — initiate handshake.
+  if (msg.type === 'protocol_capabilities' && msg.encryption === 'required') {
+    const sc = me.config.botOptions && me.config.botOptions.secureChannel;
+    const pinnedPublicKeyPem = sc && sc.pinnedPublicKeyPem;
+    if (!pinnedPublicKeyPem) {
+      console.error('[secureChannel] server requires encryption but no pinnedPublicKeyPem in chatConfig.botOptions.secureChannel');
+      return { consumed: true };
+    }
+    try {
+      me._secureChannel = new SecureChannel({
+        pinnedPublicKeyPem,
+        expectedSigningKeyId: sc && sc.expectedSigningKeyId,
+      } as any);
+      const init = await me._secureChannel.initiateHandshake();
+      me.bot.sendMessage(init);
+    } catch (e) {
+      console.error('[secureChannel] init failed:', e);
+    }
+    return { consumed: true };
+  }
+
+  // Server response to our init.
+  if (msg.type === 'key_exchange_response' && me._secureChannel) {
+    try {
+      const complete = await me._secureChannel.handleResponse(msg);
+      me.bot.sendMessage(complete);
+    } catch (e) {
+      console.error('[secureChannel] response handling failed:', e);
+    }
+    return { consumed: true };
+  }
+
+  // Server's handshake ack — channel becomes SECURE here.
+  if (msg.type === 'key_exchange_ack' && me._secureChannel) {
+    try {
+      await me._secureChannel.handleAck(msg);
+      console.log('[secureChannel] channel SECURE');
+      // Wrap outgoing sendMessage exactly once now that we're secure.
+      me._wrapBotSendMessageForEncryption();
+    } catch (e) {
+      console.error('[secureChannel] ack handling failed:', e);
+    }
+    return { consumed: true };
+  }
+
+  // Encrypted message envelope — decrypt and pass through as plaintext.
+  if (msg.type === 'secure_envelope' && me._secureChannel && me._secureChannel.isSecure()) {
+    try {
+      const plain = await me._secureChannel.decryptIncoming(msg);
+      return { consumed: false, decrypted: plain };
+    } catch (e) {
+      console.error('[secureChannel] decrypt failed:', e);
+      return { consumed: true };
+    }
+  }
+
+  return { consumed: false };
+}
+
+_wrapBotSendMessageForEncryption () {
+  const me: any = this;
+  if (me._botSendMessageWrapped) return;
+  const original = me.bot.sendMessage.bind(me.bot);
+  me.bot.sendMessage = (messageToBot: any, callback?: any) => {
+    if (me._secureChannel && me._secureChannel.isSecure()
+        && messageToBot && messageToBot.type !== 'key_exchange_init'
+        && messageToBot.type !== 'key_exchange_complete') {
+      me._secureChannel.encryptOutgoing(messageToBot)
+        .then((envelope: any) => original(envelope, callback))
+        .catch((err: any) => {
+          // Fail closed. The server requires encryption on this channel
+          // (it sent protocol_capabilities: required). Falling back to
+          // plaintext would leak sensitive message content. Drop the
+          // message and surface the error to the caller.
+          console.error('[secureChannel] encrypt outgoing failed — dropping message to avoid plaintext leak:', err);
+          if (typeof callback === 'function') {
+            try { callback(err); } catch (_) { /* noop */ }
+          }
+        });
+      return;
+    }
+    return original(messageToBot, callback);
+  };
+  me._botSendMessageWrapped = true;
+}
+
 bindSDKEvents  () {
   // hook to add custom events
   const me:any = this;
@@ -1342,13 +1440,24 @@ bindSDKEvents  () {
     me.isSocketOpened = true;
   });
 
-  me.bot.on('message', (response: { data: string; }) => {
+  me.bot.on('message', async (response: { data: string; }) => {
     // actual implementation starts here
     if (me.popupOpened === true) {
       $('.kore-auth-popup .close-popup').trigger('click');
     }
 
     let tempData = JSON.parse(response.data);
+
+    // Secure channel: intercept handshake frames and decrypt envelopes.
+    // No-op when the SDK app does not have duplexEncryptionEnabled.
+    const intercepted = await me._handleSecureChannelFrame(tempData);
+    if (intercepted.consumed) {
+      return; // handshake / control message — nothing more to do
+    }
+    if (intercepted.decrypted) {
+      tempData = intercepted.decrypted;
+    }
+
     let chatWindowEvent = {stopFurtherExecution: false};
     me.emit(me.EVENTS.ON_WS_MESSAGE,{
       messageData:tempData,

--- a/src/components/chatwindow/chatWindow.ts
+++ b/src/components/chatwindow/chatWindow.ts
@@ -1331,22 +1331,16 @@ sendWebhookOnConnectEvent  () {
   });
 };
 
-// ─────────────────────────────────────────────────────────────────────
-// Secure channel — handshake / decrypt / encrypt hooks.
-// Activated only when the server sends a `protocol_capabilities`
-// message with encryption: 'required' (because the SDK app has the
-// duplexEncryptionEnabled flag set).
-// ─────────────────────────────────────────────────────────────────────
-async _handleSecureChannelFrame (msg: any) {
+// Secure channel: ECDH+AES-GCM handshake / encrypt / decrypt hooks, active only when
+// the server requires encryption (duplexEncryptionEnabled on the SDK app).
+async handleSecureChannelFrame (msg: any) {
   const me: any = this;
   if (!msg || typeof msg !== 'object') return { consumed: false };
 
-  // Server announces it requires encryption — initiate handshake.
-  if (msg.type === 'protocol_capabilities' && msg.encryption === 'required') {
+  if (msg?.type === 'protocol_capabilities' && msg?.encryption === 'required') {
     const sc = me.config.botOptions && me.config.botOptions.secureChannel;
     const pinnedPublicKeyPem = sc && sc.pinnedPublicKeyPem;
     if (!pinnedPublicKeyPem) {
-      console.error('[secureChannel] server requires encryption but no pinnedPublicKeyPem in chatConfig.botOptions.secureChannel');
       return { consumed: true };
     }
     try {
@@ -1354,78 +1348,59 @@ async _handleSecureChannelFrame (msg: any) {
         pinnedPublicKeyPem,
         expectedSigningKeyId: sc && sc.expectedSigningKeyId,
       } as any);
-      // Arm a handshake timeout: if the server never completes the
-      // 4-step exchange (network issue, server bug, attacker stalling),
-      // tear down the channel state so the next `protocol_capabilities`
-      // can re-initiate cleanly instead of being rejected as
-      // handshake_state_invalid.
+      // Reset if the server never completes the handshake, so a later
+      // protocol_capabilities frame can re-initiate cleanly.
       const HANDSHAKE_TIMEOUT_MS = 10_000;
       me._secureChannelHandshakeTimer = setTimeout(() => {
         if (me._secureChannel && !me._secureChannel.isSecure()) {
-          console.error('[secureChannel] handshake timeout — resetting');
-          me._resetSecureChannel();
+          me.resetSecureChannel();
         }
       }, HANDSHAKE_TIMEOUT_MS);
       const init = await me._secureChannel.initiateHandshake();
       try { me.bot.sendMessage(init); } catch (sendErr) {
-        console.error('[secureChannel] failed to send key_exchange_init:', sendErr);
-        me._resetSecureChannel();
+        me.resetSecureChannel();
       }
     } catch (e) {
-      console.error('[secureChannel] init failed:', e);
-      me._resetSecureChannel();
+      me.resetSecureChannel();
     }
     return { consumed: true };
   }
 
-  // Server response to our init.
-  if (msg.type === 'key_exchange_response' && me._secureChannel) {
+  if (msg?.type === 'key_exchange_response' && me._secureChannel) {
     try {
       const complete = await me._secureChannel.handleResponse(msg);
       try { me.bot.sendMessage(complete); } catch (sendErr) {
-        console.error('[secureChannel] failed to send key_exchange_complete:', sendErr);
-        me._resetSecureChannel();
+        me.resetSecureChannel();
       }
     } catch (e) {
-      console.error('[secureChannel] response handling failed:', e);
-      me._resetSecureChannel();
+      me.resetSecureChannel();
     }
     return { consumed: true };
   }
 
-  // Server's handshake ack — channel becomes SECURE here.
-  if (msg.type === 'key_exchange_ack' && me._secureChannel) {
+  if (msg?.type === 'key_exchange_ack' && me._secureChannel) {
     try {
       await me._secureChannel.handleAck(msg);
       if (me._secureChannelHandshakeTimer) {
         clearTimeout(me._secureChannelHandshakeTimer);
         me._secureChannelHandshakeTimer = null;
       }
-      console.log('[secureChannel] channel SECURE');
-      // Wrap outgoing sendMessage exactly once now that we're secure.
-      me._wrapBotSendMessageForEncryption();
+      me.wrapBotSendMessageForEncryption();
     } catch (e) {
-      console.error('[secureChannel] ack handling failed:', e);
-      me._resetSecureChannel();
+      me.resetSecureChannel();
     }
     return { consumed: true };
   }
 
-  // Encrypted message envelope — decrypt and pass through as plaintext.
-  if (msg.type === 'secure_envelope' && me._secureChannel && me._secureChannel.isSecure()) {
+  if (msg?.type === 'secure_envelope' && me._secureChannel && me._secureChannel.isSecure()) {
     try {
       const plain: any = await me._secureChannel.decryptIncoming(msg);
-      // Decrypted __control frames (e.g. rekey_signal) are protocol
-      // metadata, not user messages. They must not be rendered.
+      // Decrypted control frames (e.g. rekey) are protocol metadata, not user messages.
       if (plain && plain.__control === true) {
-        // Reserved for future client-handled control frames (rekey_ack,
-        // session_invalidate, etc.). Today the server initiates rekey
-        // via its own handler; nothing to do client-side.
         return { consumed: true };
       }
       return { consumed: false, decrypted: plain };
     } catch (e) {
-      console.error('[secureChannel] decrypt failed:', e);
       return { consumed: true };
     }
   }
@@ -1433,12 +1408,9 @@ async _handleSecureChannelFrame (msg: any) {
   return { consumed: false };
 }
 
-// Tear down secure-channel state and restore plaintext sendMessage.
-// Called on handshake failure, handshake timeout, and WS close — these
-// are the points where leaving the wrapped sendMessage in place would
-// either drop user messages (channel_not_secure) or wrap them with a
-// key the server has already discarded.
-_resetSecureChannel () {
+// Tear down secure-channel state and restore plaintext sendMessage
+// (handshake failure / timeout / WS close).
+resetSecureChannel () {
   const me: any = this;
   if (me._secureChannelHandshakeTimer) {
     clearTimeout(me._secureChannelHandshakeTimer);
@@ -1452,14 +1424,11 @@ _resetSecureChannel () {
   me._secureChannel = null;
 }
 
-_wrapBotSendMessageForEncryption () {
+wrapBotSendMessageForEncryption () {
   const me: any = this;
   if (me._botSendMessageWrapped) return;
   const original = me.bot.sendMessage.bind(me.bot);
-  // Stash the original so _resetSecureChannel can restore the plaintext
-  // path on WS close / handshake failure. Without this, a reconnect
-  // would keep the wrapper bound to a dead manager and silently drop
-  // every outbound message.
+  // Stash the original so resetSecureChannel can restore the plaintext path on reset.
   me._botSendMessageOriginal = me.bot.sendMessage;
   me.bot.sendMessage = (messageToBot: any, callback?: any) => {
     if (me._secureChannel && me._secureChannel.isSecure()
@@ -1468,11 +1437,7 @@ _wrapBotSendMessageForEncryption () {
       me._secureChannel.encryptOutgoing(messageToBot)
         .then((envelope: any) => original(envelope, callback))
         .catch((err: any) => {
-          // Fail closed. The server requires encryption on this channel
-          // (it sent protocol_capabilities: required). Falling back to
-          // plaintext would leak sensitive message content. Drop the
-          // message and surface the error to the caller.
-          console.error('[secureChannel] encrypt outgoing failed — dropping message to avoid plaintext leak:', err);
+          // Fail closed: server requires encryption, so drop rather than leak plaintext.
           if (typeof callback === 'function') {
             try { callback(err); } catch (_) { /* noop */ }
           }
@@ -1498,23 +1463,16 @@ bindSDKEvents  () {
   });
 
   me.bot.on('message', async (response: { data: string; }) => {
-    // Outer try/catch: this is an async event handler. Any uncaught
-    // rejection here becomes an unhandledrejection on the page, which
-    // some host applications surface to users as a generic error. Keep
-    // the WS event stream alive even if a single frame is malformed.
-    try {
-    // actual implementation starts here
     if (me.popupOpened === true) {
       $('.kore-auth-popup .close-popup').trigger('click');
     }
 
     let tempData = JSON.parse(response.data);
 
-    // Secure channel: intercept handshake frames and decrypt envelopes.
-    // No-op when the SDK app does not have duplexEncryptionEnabled.
-    const intercepted = await me._handleSecureChannelFrame(tempData);
+    // Secure channel: intercept handshake frames / decrypt envelopes (no-op when not enabled).
+    const intercepted = await me.handleSecureChannelFrame(tempData);
     if (intercepted.consumed) {
-      return; // handshake / control message — nothing more to do
+      return;
     }
     if (intercepted.decrypted) {
       tempData = intercepted.decrypted;
@@ -1560,16 +1518,11 @@ bindSDKEvents  () {
       }
       me.chatEle.setAttribute('dir', langDetails?.language == 'ar' || langDetails?.newLanguage == 'ar' ? 'rtl' : 'ltr');
     }
-    } catch (handlerErr) {
-      console.error('[chatWindow] ws message handler error:', handlerErr);
-    }
   });
 
   me.bot.on('close', () => {
-    // WS closed — any subsequent reconnect needs a fresh handshake.
-    // Reset secure-channel state and unwrap sendMessage so plaintext
-    // messages are not encrypted against stale, server-discarded keys.
-    me._resetSecureChannel();
+    // WS closed — reset secure-channel state so a reconnect does a fresh handshake.
+    me.resetSecureChannel();
   });
 
   me.bot.on('webhook_ready', (response: any) => {

--- a/src/components/chatwindow/chatWindow.ts
+++ b/src/components/chatwindow/chatWindow.ts
@@ -1344,19 +1344,19 @@ async handleSecureChannelFrame (msg: any) {
       return { consumed: true };
     }
     try {
-      me._secureChannel = new SecureChannel({
+      me.secureChannel = new SecureChannel({
         pinnedPublicKeyPem,
         expectedSigningKeyId: sc && sc.expectedSigningKeyId,
       } as any);
       // Reset if the server never completes the handshake, so a later
       // protocol_capabilities frame can re-initiate cleanly.
       const HANDSHAKE_TIMEOUT_MS = 10_000;
-      me._secureChannelHandshakeTimer = setTimeout(() => {
-        if (me._secureChannel && !me._secureChannel.isSecure()) {
+      me.secureChannelHandshakeTimer = setTimeout(() => {
+        if (me.secureChannel && !me.secureChannel.isSecure()) {
           me.resetSecureChannel();
         }
       }, HANDSHAKE_TIMEOUT_MS);
-      const init = await me._secureChannel.initiateHandshake();
+      const init = await me.secureChannel.initiateHandshake();
       try { me.bot.sendMessage(init); } catch (sendErr) {
         me.resetSecureChannel();
       }
@@ -1366,9 +1366,9 @@ async handleSecureChannelFrame (msg: any) {
     return { consumed: true };
   }
 
-  if (msg?.type === 'key_exchange_response' && me._secureChannel) {
+  if (msg?.type === 'key_exchange_response' && me.secureChannel) {
     try {
-      const complete = await me._secureChannel.handleResponse(msg);
+      const complete = await me.secureChannel.handleResponse(msg);
       try { me.bot.sendMessage(complete); } catch (sendErr) {
         me.resetSecureChannel();
       }
@@ -1378,12 +1378,12 @@ async handleSecureChannelFrame (msg: any) {
     return { consumed: true };
   }
 
-  if (msg?.type === 'key_exchange_ack' && me._secureChannel) {
+  if (msg?.type === 'key_exchange_ack' && me.secureChannel) {
     try {
-      await me._secureChannel.handleAck(msg);
-      if (me._secureChannelHandshakeTimer) {
-        clearTimeout(me._secureChannelHandshakeTimer);
-        me._secureChannelHandshakeTimer = null;
+      await me.secureChannel.handleAck(msg);
+      if (me.secureChannelHandshakeTimer) {
+        clearTimeout(me.secureChannelHandshakeTimer);
+        me.secureChannelHandshakeTimer = null;
       }
       me.wrapBotSendMessageForEncryption();
     } catch (e) {
@@ -1392,9 +1392,9 @@ async handleSecureChannelFrame (msg: any) {
     return { consumed: true };
   }
 
-  if (msg?.type === 'secure_envelope' && me._secureChannel && me._secureChannel.isSecure()) {
+  if (msg?.type === 'secure_envelope' && me.secureChannel && me.secureChannel.isSecure()) {
     try {
-      const plain: any = await me._secureChannel.decryptIncoming(msg);
+      const plain: any = await me.secureChannel.decryptIncoming(msg);
       // Decrypted control frames (e.g. rekey) are protocol metadata, not user messages.
       if (plain && plain.__control === true) {
         return { consumed: true };
@@ -1412,41 +1412,41 @@ async handleSecureChannelFrame (msg: any) {
 // (handshake failure / timeout / WS close).
 resetSecureChannel () {
   const me: any = this;
-  if (me._secureChannelHandshakeTimer) {
-    clearTimeout(me._secureChannelHandshakeTimer);
-    me._secureChannelHandshakeTimer = null;
+  if (me.secureChannelHandshakeTimer) {
+    clearTimeout(me.secureChannelHandshakeTimer);
+    me.secureChannelHandshakeTimer = null;
   }
-  if (me._botSendMessageOriginal) {
-    me.bot.sendMessage = me._botSendMessageOriginal;
-    me._botSendMessageOriginal = null;
+  if (me.botSendMessageOriginal) {
+    me.bot.sendMessage = me.botSendMessageOriginal;
+    me.botSendMessageOriginal = null;
   }
-  me._botSendMessageWrapped = false;
-  me._secureChannel = null;
+  me.botSendMessageWrapped = false;
+  me.secureChannel = null;
 }
 
 wrapBotSendMessageForEncryption () {
   const me: any = this;
-  if (me._botSendMessageWrapped) return;
+  if (me.botSendMessageWrapped) return;
   const original = me.bot.sendMessage.bind(me.bot);
   // Stash the original so resetSecureChannel can restore the plaintext path on reset.
-  me._botSendMessageOriginal = me.bot.sendMessage;
+  me.botSendMessageOriginal = me.bot.sendMessage;
   me.bot.sendMessage = (messageToBot: any, callback?: any) => {
-    if (me._secureChannel && me._secureChannel.isSecure()
+    if (me.secureChannel && me.secureChannel.isSecure()
         && messageToBot && messageToBot.type !== 'key_exchange_init'
         && messageToBot.type !== 'key_exchange_complete') {
-      me._secureChannel.encryptOutgoing(messageToBot)
+      me.secureChannel.encryptOutgoing(messageToBot)
         .then((envelope: any) => original(envelope, callback))
         .catch((err: any) => {
           // Fail closed: server requires encryption, so drop rather than leak plaintext.
           if (typeof callback === 'function') {
-            try { callback(err); } catch (_) { /* noop */ }
+            try { callback(err); } catch { /* noop */ }
           }
         });
       return;
     }
     return original(messageToBot, callback);
   };
-  me._botSendMessageWrapped = true;
+  me.botSendMessageWrapped = true;
 }
 
 bindSDKEvents  () {

--- a/src/components/chatwindow/chatWindow.ts
+++ b/src/components/chatwindow/chatWindow.ts
@@ -10,7 +10,6 @@ import './sass/chatWindow.scss';
 import './sass/fonts.scss';
 //import './../../libs/emojione.sprites.css';
 import chatConfig from './config/kore-config';
-// @ts-ignore — plain JS module
 import SecureChannel from '../secureChannel/secureChannel.js';
 //import GreeetingsPlugin from '../../plugins/greetings/greetings-plugin'
 
@@ -1331,8 +1330,7 @@ sendWebhookOnConnectEvent  () {
   });
 };
 
-// Secure channel: ECDH+AES-GCM handshake / encrypt / decrypt hooks, active only when
-// the server requires encryption (duplexEncryptionEnabled on the SDK app).
+// Secure channel: ECDH+AES-GCM handshake / encrypt / decrypt hooks
 async handleSecureChannelFrame (msg: any) {
   const me: any = this;
   if (!msg || typeof msg !== 'object') return { consumed: false };
@@ -1348,8 +1346,7 @@ async handleSecureChannelFrame (msg: any) {
         pinnedPublicKeyPem,
         expectedSigningKeyId: sc && sc.expectedSigningKeyId,
       } as any);
-      // Reset if the server never completes the handshake, so a later
-      // protocol_capabilities frame can re-initiate cleanly.
+
       const HANDSHAKE_TIMEOUT_MS = 10_000;
       me.secureChannelHandshakeTimer = setTimeout(() => {
         if (me.secureChannel && !me.secureChannel.isSecure()) {
@@ -1395,7 +1392,6 @@ async handleSecureChannelFrame (msg: any) {
   if (msg?.type === 'secure_envelope' && me.secureChannel && me.secureChannel.isSecure()) {
     try {
       const plain: any = await me.secureChannel.decryptIncoming(msg);
-      // Decrypted control frames (e.g. rekey) are protocol metadata, not user messages.
       if (plain && plain.__control === true) {
         return { consumed: true };
       }
@@ -1408,8 +1404,6 @@ async handleSecureChannelFrame (msg: any) {
   return { consumed: false };
 }
 
-// Tear down secure-channel state and restore plaintext sendMessage
-// (handshake failure / timeout / WS close).
 resetSecureChannel () {
   const me: any = this;
   if (me.secureChannelHandshakeTimer) {
@@ -1428,7 +1422,6 @@ wrapBotSendMessageForEncryption () {
   const me: any = this;
   if (me.botSendMessageWrapped) return;
   const original = me.bot.sendMessage.bind(me.bot);
-  // Stash the original so resetSecureChannel can restore the plaintext path on reset.
   me.botSendMessageOriginal = me.bot.sendMessage;
   me.bot.sendMessage = (messageToBot: any, callback?: any) => {
     if (me.secureChannel && me.secureChannel.isSecure()
@@ -1437,9 +1430,8 @@ wrapBotSendMessageForEncryption () {
       me.secureChannel.encryptOutgoing(messageToBot)
         .then((envelope: any) => original(envelope, callback))
         .catch((err: any) => {
-          // Fail closed: server requires encryption, so drop rather than leak plaintext.
           if (typeof callback === 'function') {
-            try { callback(err); } catch { /* noop */ }
+            try { callback(err); } catch {}
           }
         });
       return;
@@ -1469,7 +1461,6 @@ bindSDKEvents  () {
 
     let tempData = JSON.parse(response.data);
 
-    // Secure channel: intercept handshake frames / decrypt envelopes (no-op when not enabled).
     const intercepted = await me.handleSecureChannelFrame(tempData);
     if (intercepted.consumed) {
       return;
@@ -1521,7 +1512,6 @@ bindSDKEvents  () {
   });
 
   me.bot.on('close', () => {
-    // WS closed — reset secure-channel state so a reconnect does a fresh handshake.
     me.resetSecureChannel();
   });
 

--- a/src/components/chatwindow/chatWindow.ts
+++ b/src/components/chatwindow/chatWindow.ts
@@ -1348,7 +1348,7 @@ bindSDKEvents  () {
     me.isSocketOpened = true;
   });
 
-  me.bot.on('message', async (response: { data: string; }) => {
+  me.bot.on('message', (response: { data: string; }) => {
     if (me.popupOpened === true) {
       $('.kore-auth-popup .close-popup').trigger('click');
     }

--- a/src/components/chatwindow/chatWindow.ts
+++ b/src/components/chatwindow/chatWindow.ts
@@ -288,7 +288,6 @@ initShow  (config:any) {
   }
   me.config.ttsInterface = me.config.ttsInterface || 'webapi';
   me.setConfig();
-  // Secure channel: give the RTM client a factory so it attaches the controller at construction.
   if (me.config.botOptions?.secureChannel?.pinnedPublicKeyPem) {
     me.config.botOptions.secureChannelFactory = (opts: any) => new SecureChannelController(opts);
   }
@@ -1353,9 +1352,7 @@ bindSDKEvents  () {
       $('.kore-auth-popup .close-popup').trigger('click');
     }
 
-    // Secure channel (when enabled) decrypts at the RTM chokepoint, so response.data is already plaintext.
     let tempData = JSON.parse(response.data);
-
     let chatWindowEvent = {stopFurtherExecution: false};
     me.emit(me.EVENTS.ON_WS_MESSAGE,{
       messageData:tempData,

--- a/src/components/chatwindow/chatWindow.ts
+++ b/src/components/chatwindow/chatWindow.ts
@@ -10,7 +10,8 @@ import './sass/chatWindow.scss';
 import './sass/fonts.scss';
 //import './../../libs/emojione.sprites.css';
 import chatConfig from './config/kore-config';
-import SecureChannel from '../secureChannel/secureChannel.js';
+// @ts-ignore — plain JS module
+import SecureChannelController from '../secureChannel/secureChannelController.js';
 //import GreeetingsPlugin from '../../plugins/greetings/greetings-plugin'
 
 // import welcomeScreeContainer from '../../preact/templates/base/welcomeScreeContainer/welcomeScreeContainer';
@@ -1330,115 +1331,24 @@ sendWebhookOnConnectEvent  () {
   });
 };
 
-// Secure channel: ECDH+AES-GCM handshake / encrypt / decrypt hooks
-async handleSecureChannelFrame (msg: any) {
+// Secure channel: create the ECDH+AES-GCM controller and inject it into the RTM
+// transport client, so encrypt/decrypt happen at the socket chokepoint (below
+// message enrichment, above all bot.on('message') listeners). This replaces the
+// old chatWindow sendMessage wrapper + per-listener decrypt. No-op unless the
+// integrator configured botOptions.secureChannel.pinnedPublicKeyPem.
+attachSecureChannelController () {
   const me: any = this;
-  if (!msg || typeof msg !== 'object') return { consumed: false };
-
-  if (msg?.type === 'protocol_capabilities' && msg?.encryption === 'required') {
-    const sc = me.config.botOptions && me.config.botOptions.secureChannel;
-    const pinnedPublicKeyPem = sc && sc.pinnedPublicKeyPem;
-    if (!pinnedPublicKeyPem) {
-      return { consumed: true };
-    }
-    try {
-      me.secureChannel = new SecureChannel({
-        pinnedPublicKeyPem,
-        expectedSigningKeyId: sc && sc.expectedSigningKeyId,
-      } as any);
-
-      const HANDSHAKE_TIMEOUT_MS = 10_000;
-      me.secureChannelHandshakeTimer = setTimeout(() => {
-        if (me.secureChannel && !me.secureChannel.isSecure()) {
-          me.resetSecureChannel();
-        }
-      }, HANDSHAKE_TIMEOUT_MS);
-      const init = await me.secureChannel.initiateHandshake();
-      try { me.bot.sendMessage(init); } catch (sendErr) {
-        me.resetSecureChannel();
-      }
-    } catch (e) {
-      me.resetSecureChannel();
-    }
-    return { consumed: true };
-  }
-
-  if (msg?.type === 'key_exchange_response' && me.secureChannel) {
-    try {
-      const complete = await me.secureChannel.handleResponse(msg);
-      try { me.bot.sendMessage(complete); } catch (sendErr) {
-        me.resetSecureChannel();
-      }
-    } catch (e) {
-      me.resetSecureChannel();
-    }
-    return { consumed: true };
-  }
-
-  if (msg?.type === 'key_exchange_ack' && me.secureChannel) {
-    try {
-      await me.secureChannel.handleAck(msg);
-      if (me.secureChannelHandshakeTimer) {
-        clearTimeout(me.secureChannelHandshakeTimer);
-        me.secureChannelHandshakeTimer = null;
-      }
-      me.wrapBotSendMessageForEncryption();
-    } catch (e) {
-      me.resetSecureChannel();
-    }
-    return { consumed: true };
-  }
-
-  if (msg?.type === 'secure_envelope' && me.secureChannel && me.secureChannel.isSecure()) {
-    try {
-      const plain: any = await me.secureChannel.decryptIncoming(msg);
-      if (plain && plain.__control === true) {
-        return { consumed: true };
-      }
-      return { consumed: false, decrypted: plain };
-    } catch (e) {
-      return { consumed: true };
-    }
-  }
-
-  return { consumed: false };
-}
-
-resetSecureChannel () {
-  const me: any = this;
-  if (me.secureChannelHandshakeTimer) {
-    clearTimeout(me.secureChannelHandshakeTimer);
-    me.secureChannelHandshakeTimer = null;
-  }
-  if (me.botSendMessageOriginal) {
-    me.bot.sendMessage = me.botSendMessageOriginal;
-    me.botSendMessageOriginal = null;
-  }
-  me.botSendMessageWrapped = false;
-  me.secureChannel = null;
-}
-
-wrapBotSendMessageForEncryption () {
-  const me: any = this;
-  if (me.botSendMessageWrapped) return;
-  const original = me.bot.sendMessage.bind(me.bot);
-  me.botSendMessageOriginal = me.bot.sendMessage;
-  me.bot.sendMessage = (messageToBot: any, callback?: any) => {
-    if (me.secureChannel && me.secureChannel.isSecure()
-        && messageToBot && messageToBot.type !== 'key_exchange_init'
-        && messageToBot.type !== 'key_exchange_complete') {
-      me.secureChannel.encryptOutgoing(messageToBot)
-        .then((envelope: any) => original(envelope, callback))
-        .catch((err: any) => {
-          if (typeof callback === 'function') {
-            try { callback(err); } catch {}
-          }
-        });
-      return;
-    }
-    return original(messageToBot, callback);
-  };
-  me.botSendMessageWrapped = true;
+  const sc = me.config.botOptions && me.config.botOptions.secureChannel;
+  const pinnedPublicKeyPem = sc && sc.pinnedPublicKeyPem;
+  if (!pinnedPublicKeyPem) return;
+  const rtm = me.bot && me.bot.RtmClient;
+  if (!rtm || rtm._secureChannel) return; // no client yet, or already attached
+  rtm._secureChannel = new SecureChannelController({
+    config: { pinnedPublicKeyPem, expectedSigningKeyId: sc && sc.expectedSigningKeyId },
+    // Handshake/rekey frames must bypass the encrypt path and go out plaintext.
+    rawSend: (frame: any) => rtm._rawSend(frame),
+    logger: (m: any) => { try { (console.debug || console.log).call(console, m); } catch (e) { /* noop */ } },
+  } as any);
 }
 
 bindSDKEvents  () {
@@ -1459,15 +1369,9 @@ bindSDKEvents  () {
       $('.kore-auth-popup .close-popup').trigger('click');
     }
 
+    // When the secure channel is enabled, decryption happens at the RTM transport
+    // chokepoint, so response.data is already plaintext here.
     let tempData = JSON.parse(response.data);
-
-    const intercepted = await me.handleSecureChannelFrame(tempData);
-    if (intercepted.consumed) {
-      return;
-    }
-    if (intercepted.decrypted) {
-      tempData = intercepted.decrypted;
-    }
 
     let chatWindowEvent = {stopFurtherExecution: false};
     me.emit(me.EVENTS.ON_WS_MESSAGE,{
@@ -1511,8 +1415,12 @@ bindSDKEvents  () {
     }
   });
 
-  me.bot.on('close', () => {
-    me.resetSecureChannel();
+  me.bot.on('rtm_client_initialized', () => {
+    // Attach the secure-channel controller to the RTM transport client once it
+    // exists. Encrypt/decrypt live at the socket chokepoint, and the RTM client
+    // resets the channel on ws_close so reconnect performs a fresh handshake —
+    // no bot-level 'close' reset is needed here.
+    me.attachSecureChannelController();
   });
 
   me.bot.on('webhook_ready', (response: any) => {

--- a/src/components/chatwindow/chatWindow.ts
+++ b/src/components/chatwindow/chatWindow.ts
@@ -288,9 +288,13 @@ initShow  (config:any) {
   }
   me.config.ttsInterface = me.config.ttsInterface || 'webapi';
   me.setConfig();
+  // Secure channel: give the RTM client a factory so it attaches the controller at construction.
+  if (me.config.botOptions?.secureChannel?.pinnedPublicKeyPem) {
+    me.config.botOptions.secureChannelFactory = (opts: any) => new SecureChannelController(opts);
+  }
   if(!me.config?.mockMode?.enable && me.config.UI.version == 'v3'){
   me.bot.init(me.config.botOptions, me.config.messageHistoryLimit);
-  }  
+  }
   me.bot.on('jwtgrantsuccess', (response: { jwtgrantsuccess: any; }) => {
     me.config.jwtGrantSuccessInformation = response.jwtgrantsuccess;
     if (!me.config?.autoConnect && !me.isUIInitialized) {
@@ -1331,26 +1335,6 @@ sendWebhookOnConnectEvent  () {
   });
 };
 
-// Secure channel: create the ECDH+AES-GCM controller and inject it into the RTM
-// transport client, so encrypt/decrypt happen at the socket chokepoint (below
-// message enrichment, above all bot.on('message') listeners). This replaces the
-// old chatWindow sendMessage wrapper + per-listener decrypt. No-op unless the
-// integrator configured botOptions.secureChannel.pinnedPublicKeyPem.
-attachSecureChannelController () {
-  const me: any = this;
-  const sc = me.config.botOptions && me.config.botOptions.secureChannel;
-  const pinnedPublicKeyPem = sc && sc.pinnedPublicKeyPem;
-  if (!pinnedPublicKeyPem) return;
-  const rtm = me.bot && me.bot.RtmClient;
-  if (!rtm || rtm._secureChannel) return; // no client yet, or already attached
-  rtm._secureChannel = new SecureChannelController({
-    config: { pinnedPublicKeyPem, expectedSigningKeyId: sc && sc.expectedSigningKeyId },
-    // Handshake/rekey frames must bypass the encrypt path and go out plaintext.
-    rawSend: (frame: any) => rtm._rawSend(frame),
-    logger: (m: any) => { try { (console.debug || console.log).call(console, m); } catch (e) { /* noop */ } },
-  } as any);
-}
-
 bindSDKEvents  () {
   // hook to add custom events
   const me:any = this;
@@ -1369,8 +1353,7 @@ bindSDKEvents  () {
       $('.kore-auth-popup .close-popup').trigger('click');
     }
 
-    // When the secure channel is enabled, decryption happens at the RTM transport
-    // chokepoint, so response.data is already plaintext here.
+    // Secure channel (when enabled) decrypts at the RTM chokepoint, so response.data is already plaintext.
     let tempData = JSON.parse(response.data);
 
     let chatWindowEvent = {stopFurtherExecution: false};
@@ -1413,14 +1396,6 @@ bindSDKEvents  () {
       }
       me.chatEle.setAttribute('dir', langDetails?.language == 'ar' || langDetails?.newLanguage == 'ar' ? 'rtl' : 'ltr');
     }
-  });
-
-  me.bot.on('rtm_client_initialized', () => {
-    // Attach the secure-channel controller to the RTM transport client once it
-    // exists. Encrypt/decrypt live at the socket chokepoint, and the RTM client
-    // resets the channel on ws_close so reconnect performs a fresh handshake —
-    // no bot-level 'close' reset is needed here.
-    me.attachSecureChannelController();
   });
 
   me.bot.on('webhook_ready', (response: any) => {

--- a/src/components/chatwindow/config/kore-config.ts
+++ b/src/components/chatwindow/config/kore-config.ts
@@ -51,6 +51,8 @@ botOptions.webSocketConfig = {
 //     port: 'PORT_TO_BE_REWRITTEN'
 // };
 
+botOptions.secureChannel = ''; // add public key and signing key for secure duplex communication. Please refer docs for more info
+
 chatConfig = {
     mockMode:{
         enable:false

--- a/src/components/secureChannel/secureChannel.js
+++ b/src/components/secureChannel/secureChannel.js
@@ -1,0 +1,369 @@
+// Browser-side secure channel client.
+// Speaks the same wire protocol as koreserver/services/SecureChannel/.
+//
+// Public API:
+//   const sc = new SecureChannel({ pinnedPublicKeyPem, sessionId });
+//   await sc.initiateHandshake() → returns the key_exchange_init wire object
+//   sc.handleResponse(msg) → returns the key_exchange_complete wire object (Promise)
+//   sc.handleAck(msg) → marks channel SECURE (Promise)
+//   sc.encryptOutgoing(plainObj) → returns secure_envelope wire object
+//   sc.decryptIncoming(envelope) → returns plain object
+//   sc.isSecure() → bool
+//
+// Uses window.crypto.subtle for all cryptography. No dependencies.
+
+const PROTOCOL_VERSION = 'rtm-ecdh-v1';
+const NONCE_BYTES = 16;
+const IV_BYTES = 12;
+const TAG_BYTES = 16;
+const AES_KEY_BITS = 256;
+const EC_RAW_PUBKEY_BYTES = 65;
+
+const STATE = {
+    INIT: 'INIT',
+    AWAITING_RESPONSE: 'AWAITING_RESPONSE',
+    AWAITING_ACK: 'AWAITING_ACK',
+    SECURE: 'SECURE',
+    FAILED: 'FAILED',
+};
+
+const MSG = {
+    INIT: 'key_exchange_init',
+    RESPONSE: 'key_exchange_response',
+    COMPLETE: 'key_exchange_complete',
+    ACK: 'key_exchange_ack',
+    ENVELOPE: 'secure_envelope',
+    REKEY_SIGNAL: 'rekey_signal',
+    REKEY_ACK: 'rekey_ack',
+    CAPABILITIES: 'protocol_capabilities',
+};
+
+const HANDSHAKE_TOKEN_C2S = 'rtm-handshake-ok';
+const HANDSHAKE_TOKEN_S2C = 'rtm-handshake-server-ok';
+
+// ---------- encoding helpers ----------
+function b64encode(buf) {
+    const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
+    let s = '';
+    for (let i = 0; i < bytes.length; i += 1) s += String.fromCharCode(bytes[i]);
+    return btoa(s);
+}
+function b64decode(s) {
+    const bin = atob(s);
+    const out = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i += 1) out[i] = bin.charCodeAt(i);
+    return out;
+}
+function concatBytes(...arrays) {
+    const total = arrays.reduce((acc, a) => acc + a.length, 0);
+    const out = new Uint8Array(total);
+    let off = 0;
+    for (const a of arrays) { out.set(a, off); off += a.length; }
+    return out;
+}
+function utf8encode(s) { return new TextEncoder().encode(s); }
+function utf8decode(b) { return new TextDecoder().decode(b); }
+
+// ---------- IV (counter-based) ----------
+function ivFromCounter(counter /* BigInt */) {
+    if (counter < 0n || counter >= (1n << 63n)) {
+        throw new Error('counter_overflow_force_rekey');
+    }
+    const iv = new Uint8Array(IV_BYTES);
+    const view = new DataView(iv.buffer);
+    // 4 leading zero bytes already set; write counter as BE uint64 at offset 4
+    const hi = Number((counter >> 32n) & 0xffffffffn);
+    const lo = Number(counter & 0xffffffffn);
+    view.setUint32(IV_BYTES - 8, hi, false);
+    view.setUint32(IV_BYTES - 4, lo, false);
+    return iv;
+}
+
+// ---------- subtle helpers ----------
+async function importAesGcmKey(rawBytes) {
+    return window.crypto.subtle.importKey(
+        'raw', rawBytes,
+        { name: 'AES-GCM' },
+        false, ['encrypt', 'decrypt'],
+    );
+}
+async function aesGcmEncrypt(aesKey, iv, plainBuf) {
+    const out = await window.crypto.subtle.encrypt(
+        { name: 'AES-GCM', iv },
+        aesKey, plainBuf,
+    );
+    // SubtleCrypto AES-GCM returns ciphertext || tag. Split.
+    const total = new Uint8Array(out);
+    const tag = total.slice(total.length - TAG_BYTES);
+    const ct = total.slice(0, total.length - TAG_BYTES);
+    return { ct, tag };
+}
+async function aesGcmDecrypt(aesKey, iv, ct, tag) {
+    const combined = concatBytes(ct, tag);
+    const plain = await window.crypto.subtle.decrypt(
+        { name: 'AES-GCM', iv },
+        aesKey, combined,
+    );
+    return new Uint8Array(plain);
+}
+async function hkdfDerive(sharedSecret, salt, info, lengthBytes) {
+    const ikm = await window.crypto.subtle.importKey(
+        'raw', sharedSecret,
+        { name: 'HKDF' },
+        false, ['deriveBits'],
+    );
+    const bits = await window.crypto.subtle.deriveBits(
+        { name: 'HKDF', hash: 'SHA-256', salt, info: utf8encode(info) },
+        ikm, lengthBytes * 8,
+    );
+    return new Uint8Array(bits);
+}
+
+// SubjectPublicKeyInfo prefix for an uncompressed P-256 EC raw point.
+const SPKI_PREFIX_P256 = new Uint8Array([
+    0x30, 0x59, 0x30, 0x13, 0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01,
+    0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07, 0x03, 0x42, 0x00,
+]);
+
+async function importEcdhPubFromRaw(rawBytes) {
+    return window.crypto.subtle.importKey(
+        'spki', concatBytes(SPKI_PREFIX_P256, rawBytes),
+        { name: 'ECDH', namedCurve: 'P-256' },
+        false, [],
+    );
+}
+
+async function exportRawPubFromKey(publicKey) {
+    const spki = new Uint8Array(await window.crypto.subtle.exportKey('spki', publicKey));
+    return spki.slice(spki.length - EC_RAW_PUBKEY_BYTES);
+}
+
+async function ecdhDeriveSharedSecret(privateKey, peerRawPub) {
+    const peerKey = await importEcdhPubFromRaw(peerRawPub);
+    const bits = await window.crypto.subtle.deriveBits(
+        { name: 'ECDH', public: peerKey },
+        privateKey, 256,
+    );
+    return new Uint8Array(bits);
+}
+
+async function importEcdsaVerifyKey(pemPublicKey) {
+    // Strip PEM headers; decode base64 to DER bytes
+    const b64 = pemPublicKey.replace(/-----BEGIN [^-]+-----|-----END [^-]+-----|\s+/g, '');
+    const der = b64decode(b64);
+    return window.crypto.subtle.importKey(
+        'spki', der,
+        { name: 'ECDSA', namedCurve: 'P-256' },
+        false, ['verify'],
+    );
+}
+
+// ECDSA signatures from Node's crypto come in DER format. Web Crypto wants
+// raw r||s (64 bytes for P-256). Convert.
+function derToJoseEcdsaP256(derBytes) {
+    // DER: 0x30 len 0x02 lenR R 0x02 lenS S
+    const view = new Uint8Array(derBytes);
+    if (view[0] !== 0x30) throw new Error('bad_der_signature');
+    let offset = 2;
+    if (view[1] & 0x80) offset = 2 + (view[1] & 0x7f);
+    if (view[offset] !== 0x02) throw new Error('bad_der_signature_r');
+    const rLen = view[offset + 1];
+    let r = view.slice(offset + 2, offset + 2 + rLen);
+    offset = offset + 2 + rLen;
+    if (view[offset] !== 0x02) throw new Error('bad_der_signature_s');
+    const sLen = view[offset + 1];
+    let s = view.slice(offset + 2, offset + 2 + sLen);
+    // Strip leading zeros and left-pad to 32 bytes
+    if (r[0] === 0x00 && r.length === 33) r = r.slice(1);
+    if (s[0] === 0x00 && s.length === 33) s = s.slice(1);
+    const rOut = new Uint8Array(32); rOut.set(r, 32 - r.length);
+    const sOut = new Uint8Array(32); sOut.set(s, 32 - s.length);
+    return concatBytes(rOut, sOut);
+}
+
+// ---------- main class ----------
+class SecureChannel {
+    constructor({ pinnedPublicKeyPem, sessionId, expectedSigningKeyId } = {}) {
+        if (!pinnedPublicKeyPem) {
+            throw new Error('SecureChannel: pinnedPublicKeyPem is required');
+        }
+        this.pinnedPublicKeyPem = pinnedPublicKeyPem;
+        this.expectedSigningKeyId = expectedSigningKeyId || null;
+        this.sessionId = sessionId || self.crypto.randomUUID();
+
+        this.state = STATE.INIT;
+        this.privateKey = null;
+        this.publicKeyRaw = null;
+        this.c2sNonce = null;
+        this.s2cNonce = null;
+        this.sharedSecret = null;
+        this.salt = null;
+        this.generation = 0;
+        this.k_c2s = null;     // CryptoKey (AES-GCM)
+        this.k_s2c = null;     // CryptoKey (AES-GCM)
+        this.c2sSeq = 0n;
+        this.s2cSeq = 0n;
+
+        // Serialization locks. SubtleCrypto operations yield to the event
+        // loop, so without these the counters can be read by two concurrent
+        // callers before either has incremented — causing IV reuse on encrypt
+        // (catastrophic for AES-GCM) and counter desync on decrypt.
+        this._outboundLock = Promise.resolve();
+        this._inboundLock = Promise.resolve();
+    }
+
+    async initiateHandshake() {
+        if (this.state !== STATE.INIT) throw new Error('handshake_state_invalid');
+        const kp = await window.crypto.subtle.generateKey(
+            { name: 'ECDH', namedCurve: 'P-256' },
+            false, // not extractable — keeps private key inside SubtleCrypto
+            ['deriveBits'],
+        );
+        this.privateKey = kp.privateKey;
+        this.publicKeyRaw = await exportRawPubFromKey(kp.publicKey);
+        this.c2sNonce = window.crypto.getRandomValues(new Uint8Array(NONCE_BYTES));
+
+        this.state = STATE.AWAITING_RESPONSE;
+        return {
+            type: MSG.INIT,
+            version: PROTOCOL_VERSION,
+            clientPublicKey: b64encode(this.publicKeyRaw),
+            c2sNonce: b64encode(this.c2sNonce),
+            sessionId: this.sessionId,
+        };
+    }
+
+    async handleResponse(msg) {
+        if (this.state !== STATE.AWAITING_RESPONSE) throw new Error('handshake_state_invalid');
+        if (!msg || msg.type !== MSG.RESPONSE) throw new Error('expected_key_exchange_response');
+        if (this.expectedSigningKeyId && msg.signingKeyId !== this.expectedSigningKeyId) {
+            throw new Error('signing_key_id_mismatch');
+        }
+        const serverPubBuf = b64decode(msg.serverPublicKey);
+        if (serverPubBuf.length !== EC_RAW_PUBKEY_BYTES) throw new Error('server_pub_wrong_size');
+        const s2cNonce = b64decode(msg.s2cNonce);
+        const sigDer = b64decode(msg.sig);
+
+        // Verify the server signature
+        const verifyKey = await importEcdsaVerifyKey(this.pinnedPublicKeyPem);
+        const sigInput = concatBytes(
+            this.publicKeyRaw, serverPubBuf,
+            this.c2sNonce, s2cNonce,
+            utf8encode(msg.sessionId),
+        );
+        const sigJose = derToJoseEcdsaP256(sigDer);
+        const ok = await window.crypto.subtle.verify(
+            { name: 'ECDSA', hash: 'SHA-256' },
+            verifyKey, sigJose, sigInput,
+        );
+        if (!ok) throw new Error('server_signature_invalid');
+
+        // ECDH + key derivation
+        this.sharedSecret = await ecdhDeriveSharedSecret(this.privateKey, serverPubBuf);
+        this.salt = concatBytes(this.c2sNonce, s2cNonce);
+        this.s2cNonce = s2cNonce;
+        this.sessionId = msg.sessionId;
+        await this._installGeneration(0);
+
+        // Build the encrypted complete message
+        const iv = ivFromCounter(this.c2sSeq);
+        const plainBuf = utf8encode(HANDSHAKE_TOKEN_C2S);
+        const { ct, tag } = await aesGcmEncrypt(this.k_c2s, iv, plainBuf);
+        this.c2sSeq += 1n;
+
+        this.state = STATE.AWAITING_ACK;
+        return {
+            type: MSG.COMPLETE,
+            iv: b64encode(iv),
+            ciphertext: b64encode(ct),
+            tag: b64encode(tag),
+        };
+    }
+
+    async handleAck(msg) {
+        if (this.state !== STATE.AWAITING_ACK) throw new Error('handshake_state_invalid');
+        if (!msg || msg.type !== MSG.ACK) throw new Error('expected_key_exchange_ack');
+        const iv = b64decode(msg.iv);
+        const ct = b64decode(msg.ciphertext);
+        const tag = b64decode(msg.tag);
+        const expectedIv = ivFromCounter(this.s2cSeq);
+        if (!_buffersEqual(iv, expectedIv)) throw new Error('ack_iv_mismatch');
+        const plainBuf = await aesGcmDecrypt(this.k_s2c, iv, ct, tag);
+        const plain = utf8decode(plainBuf);
+        if (plain !== HANDSHAKE_TOKEN_S2C) throw new Error('ack_token_mismatch');
+        this.s2cSeq += 1n;
+        this.state = STATE.SECURE;
+    }
+
+    // Serialized via _outboundLock: each call awaits the previous one. This
+    // guarantees one outbound encrypt is in-flight at a time, so c2sSeq is
+    // never read by two parallel callers — preventing AES-GCM IV reuse, the
+    // forbidden-attack condition for confidentiality.
+    encryptOutgoing(plainObj) {
+        const result = this._outboundLock.then(async () => {
+            if (this.state !== STATE.SECURE) throw new Error('channel_not_secure');
+            const iv = ivFromCounter(this.c2sSeq);
+            const plainBuf = utf8encode(JSON.stringify(plainObj));
+            const { ct, tag } = await aesGcmEncrypt(this.k_c2s, iv, plainBuf);
+            this.c2sSeq += 1n;
+            return {
+                type: MSG.ENVELOPE,
+                gen: this.generation,
+                iv: b64encode(iv),
+                ciphertext: b64encode(ct),
+                tag: b64encode(tag),
+            };
+        });
+        // Chain regardless of outcome so the queue keeps moving on failure.
+        this._outboundLock = result.catch(() => undefined);
+        return result;
+    }
+
+    // Serialized via _inboundLock. WebSocket delivers frames in order, but
+    // when the message handler is async, the JS event loop can dispatch the
+    // next frame before the previous decrypt completes. Without this lock the
+    // second decrypt would read a stale s2cSeq, fail iv_sequence_mismatch,
+    // and permanently desync the channel.
+    decryptIncoming(envelope) {
+        const result = this._inboundLock.then(async () => {
+            if (this.state !== STATE.SECURE) throw new Error('channel_not_secure');
+            if (!envelope || envelope.type !== MSG.ENVELOPE) throw new Error('expected_envelope');
+            if (envelope.gen !== this.generation) {
+                throw new Error('generation_mismatch expected=' + this.generation + ' got=' + envelope.gen);
+            }
+            const iv = b64decode(envelope.iv);
+            const ct = b64decode(envelope.ciphertext);
+            const tag = b64decode(envelope.tag);
+            const expectedIv = ivFromCounter(this.s2cSeq);
+            if (!_buffersEqual(iv, expectedIv)) throw new Error('iv_sequence_mismatch');
+            const plainBuf = await aesGcmDecrypt(this.k_s2c, iv, ct, tag);
+            this.s2cSeq += 1n;
+            return JSON.parse(utf8decode(plainBuf));
+        });
+        this._inboundLock = result.catch(() => undefined);
+        return result;
+    }
+
+    isSecure() { return this.state === STATE.SECURE; }
+    isFailed() { return this.state === STATE.FAILED; }
+
+    async _installGeneration(gen) {
+        const k_c2s_raw = await hkdfDerive(this.sharedSecret, this.salt, 'c2s|gen' + gen, 32);
+        const k_s2c_raw = await hkdfDerive(this.sharedSecret, this.salt, 's2c|gen' + gen, 32);
+        this.k_c2s = await importAesGcmKey(k_c2s_raw);
+        this.k_s2c = await importAesGcmKey(k_s2c_raw);
+        this.generation = gen;
+        this.c2sSeq = 0n;
+        this.s2cSeq = 0n;
+    }
+}
+
+function _buffersEqual(a, b) {
+    if (a.length !== b.length) return false;
+    let r = 0;
+    for (let i = 0; i < a.length; i += 1) r |= a[i] ^ b[i];
+    return r === 0;
+}
+
+export { SecureChannel, STATE, MSG };
+export default SecureChannel;

--- a/src/components/secureChannel/secureChannel.js
+++ b/src/components/secureChannel/secureChannel.js
@@ -205,8 +205,8 @@ class SecureChannel {
         // loop, so without these the counters can be read by two concurrent
         // callers before either has incremented — causing IV reuse on encrypt
         // (catastrophic for AES-GCM) and counter desync on decrypt.
-        this._outboundLock = Promise.resolve();
-        this._inboundLock = Promise.resolve();
+        this.outboundLock = Promise.resolve();
+        this.inboundLock = Promise.resolve();
     }
 
     async initiateHandshake() {
@@ -260,7 +260,7 @@ class SecureChannel {
         this.salt = concatBytes(this.c2sNonce, s2cNonce);
         this.s2cNonce = s2cNonce;
         this.sessionId = msg.sessionId;
-        await this._installGeneration(0);
+        await this.installGeneration(0);
 
         // Build the encrypted complete message
         const iv = ivFromCounter(this.c2sSeq);
@@ -284,7 +284,7 @@ class SecureChannel {
         const ct = b64decode(msg.ciphertext);
         const tag = b64decode(msg.tag);
         const expectedIv = ivFromCounter(this.s2cSeq);
-        if (!_buffersEqual(iv, expectedIv)) throw new Error('ack_iv_mismatch');
+        if (!buffersEqual(iv, expectedIv)) throw new Error('ack_iv_mismatch');
         const plainBuf = await aesGcmDecrypt(this.k_s2c, iv, ct, tag);
         const plain = utf8decode(plainBuf);
         if (plain !== HANDSHAKE_TOKEN_S2C) throw new Error('ack_token_mismatch');
@@ -292,12 +292,12 @@ class SecureChannel {
         this.state = STATE.SECURE;
     }
 
-    // Serialized via _outboundLock: each call awaits the previous one. This
+    // Serialized via outboundLock: each call awaits the previous one. This
     // guarantees one outbound encrypt is in-flight at a time, so c2sSeq is
     // never read by two parallel callers — preventing AES-GCM IV reuse, the
     // forbidden-attack condition for confidentiality.
     encryptOutgoing(plainObj) {
-        const result = this._outboundLock.then(async () => {
+        const result = this.outboundLock.then(async () => {
             if (this.state !== STATE.SECURE) throw new Error('channel_not_secure');
             const iv = ivFromCounter(this.c2sSeq);
             const plainBuf = utf8encode(JSON.stringify(plainObj));
@@ -312,17 +312,17 @@ class SecureChannel {
             };
         });
         // Chain regardless of outcome so the queue keeps moving on failure.
-        this._outboundLock = result.catch(() => undefined);
+        this.outboundLock = result.catch(() => undefined);
         return result;
     }
 
-    // Serialized via _inboundLock. WebSocket delivers frames in order, but
+    // Serialized via inboundLock. WebSocket delivers frames in order, but
     // when the message handler is async, the JS event loop can dispatch the
     // next frame before the previous decrypt completes. Without this lock the
     // second decrypt would read a stale s2cSeq, fail iv_sequence_mismatch,
     // and permanently desync the channel.
     decryptIncoming(envelope) {
-        const result = this._inboundLock.then(async () => {
+        const result = this.inboundLock.then(async () => {
             if (this.state !== STATE.SECURE) throw new Error('channel_not_secure');
             if (!envelope || envelope.type !== MSG.ENVELOPE) throw new Error('expected_envelope');
             if (envelope.gen !== this.generation) {
@@ -332,19 +332,19 @@ class SecureChannel {
             const ct = b64decode(envelope.ciphertext);
             const tag = b64decode(envelope.tag);
             const expectedIv = ivFromCounter(this.s2cSeq);
-            if (!_buffersEqual(iv, expectedIv)) throw new Error('iv_sequence_mismatch');
+            if (!buffersEqual(iv, expectedIv)) throw new Error('iv_sequence_mismatch');
             const plainBuf = await aesGcmDecrypt(this.k_s2c, iv, ct, tag);
             this.s2cSeq += 1n;
             return JSON.parse(utf8decode(plainBuf));
         });
-        this._inboundLock = result.catch(() => undefined);
+        this.inboundLock = result.catch(() => undefined);
         return result;
     }
 
     isSecure() { return this.state === STATE.SECURE; }
     isFailed() { return this.state === STATE.FAILED; }
 
-    async _installGeneration(gen) {
+    async installGeneration(gen) {
         const k_c2s_raw = await hkdfDerive(this.sharedSecret, this.salt, 'c2s|gen' + gen, 32);
         const k_s2c_raw = await hkdfDerive(this.sharedSecret, this.salt, 's2c|gen' + gen, 32);
         this.k_c2s = await importAesGcmKey(k_c2s_raw);
@@ -355,7 +355,7 @@ class SecureChannel {
     }
 }
 
-function _buffersEqual(a, b) {
+function buffersEqual(a, b) {
     if (a.length !== b.length) return false;
     let r = 0;
     for (let i = 0; i < a.length; i += 1) r |= a[i] ^ b[i];

--- a/src/components/secureChannel/secureChannel.js
+++ b/src/components/secureChannel/secureChannel.js
@@ -1,16 +1,5 @@
-// Browser-side secure channel client.
-// Speaks the same wire protocol as koreserver/services/SecureChannel/.
-//
-// Public API:
-//   const sc = new SecureChannel({ pinnedPublicKeyPem, sessionId });
-//   await sc.initiateHandshake() → returns the key_exchange_init wire object
-//   sc.handleResponse(msg) → returns the key_exchange_complete wire object (Promise)
-//   sc.handleAck(msg) → marks channel SECURE (Promise)
-//   sc.encryptOutgoing(plainObj) → returns secure_envelope wire object
-//   sc.decryptIncoming(envelope) → returns plain object
-//   sc.isSecure() → bool
-//
-// Uses window.crypto.subtle for all cryptography. No dependencies.
+// Browser-side secure channel client: ECDH + AES-GCM via window.crypto.subtle,
+// wire-compatible with koreserver/services/SecureChannel/.
 
 const PROTOCOL_VERSION = 'rtm-ecdh-v1';
 const NONCE_BYTES = 16;

--- a/src/components/secureChannel/secureChannel.js
+++ b/src/components/secureChannel/secureChannel.js
@@ -187,6 +187,14 @@ class SecureChannel {
         if (!pinnedPublicKeyPem) {
             throw new Error('SecureChannel: pinnedPublicKeyPem is required');
         }
+        // Fail fast on malformed PEM so callers see a clear error at
+        // construction time rather than an opaque importKey() rejection
+        // mid-handshake (which kills the channel after a network round-trip).
+        if (typeof pinnedPublicKeyPem !== 'string'
+            || !/-----BEGIN [A-Z ]*PUBLIC KEY-----/.test(pinnedPublicKeyPem)
+            || !/-----END [A-Z ]*PUBLIC KEY-----/.test(pinnedPublicKeyPem)) {
+            throw new Error('SecureChannel: pinnedPublicKeyPem is not a valid PEM SPKI public key');
+        }
         this.pinnedPublicKeyPem = pinnedPublicKeyPem;
         this.expectedSigningKeyId = expectedSigningKeyId || null;
         this.sessionId = sessionId || self.crypto.randomUUID();

--- a/src/components/secureChannel/secureChannel.js
+++ b/src/components/secureChannel/secureChannel.js
@@ -313,6 +313,38 @@ class SecureChannel {
         return result;
     }
 
+    // Handle a server-initiated rekey. The server sends {__control:rekey_signal,newGen}
+    // encrypted on the CURRENT generation; decryptIncoming() has already unwrapped it and
+    // passes the control object here. We install the new generation (fresh k_c2s/k_s2c,
+    // counters reset to 0) and return a rekey_ack envelope encrypted on the NEW generation
+    // (client->server key). Mirrors koreserver SecureChannelManager.handleRekeySignal.
+    //
+    // Serialized on the outbound lock so the generation swap + ack encrypt cannot interleave
+    // with a concurrent outgoing encrypt (which would read a half-swapped key/counter).
+    handleRekeySignal(controlMsg) {
+        const result = this.outboundLock.then(async () => {
+            if (this.state !== STATE.SECURE) throw new Error('channel_not_secure');
+            const newGen = controlMsg && controlMsg.newGen;
+            if (typeof newGen !== 'number' || newGen !== this.generation + 1) {
+                throw new Error('rekey_invalid_generation');
+            }
+            await this.installGeneration(newGen); // derives new keys, resets c2sSeq/s2cSeq
+            const iv = ivFromCounter(this.c2sSeq);
+            const plainBuf = utf8encode(JSON.stringify({ __control: MSG.REKEY_ACK, acceptedGen: newGen }));
+            const { ct, tag } = await aesGcmEncrypt(this.k_c2s, iv, plainBuf);
+            this.c2sSeq += 1n;
+            return {
+                type: MSG.ENVELOPE,
+                gen: this.generation,
+                iv: b64encode(iv),
+                ciphertext: b64encode(ct),
+                tag: b64encode(tag),
+            };
+        });
+        this.outboundLock = result.catch(() => undefined);
+        return result;
+    }
+
     isSecure() { return this.state === STATE.SECURE; }
     isFailed() { return this.state === STATE.FAILED; }
 

--- a/src/components/secureChannel/secureChannel.js
+++ b/src/components/secureChannel/secureChannel.js
@@ -313,7 +313,6 @@ class SecureChannel {
         return result;
     }
 
-    // Install the server-signalled new generation and ack it on the new gen; serialized on outboundLock.
     handleRekeySignal(controlMsg) {
         const result = this.outboundLock.then(async () => {
             if (this.state !== STATE.SECURE) throw new Error('channel_not_secure');

--- a/src/components/secureChannel/secureChannel.js
+++ b/src/components/secureChannel/secureChannel.js
@@ -359,5 +359,5 @@ function buffersEqual(a, b) {
     return r === 0;
 }
 
-export { SecureChannel, STATE, MSG };
+export { STATE, MSG };
 export default SecureChannel;

--- a/src/components/secureChannel/secureChannel.js
+++ b/src/components/secureChannel/secureChannel.js
@@ -313,14 +313,7 @@ class SecureChannel {
         return result;
     }
 
-    // Handle a server-initiated rekey. The server sends {__control:rekey_signal,newGen}
-    // encrypted on the CURRENT generation; decryptIncoming() has already unwrapped it and
-    // passes the control object here. We install the new generation (fresh k_c2s/k_s2c,
-    // counters reset to 0) and return a rekey_ack envelope encrypted on the NEW generation
-    // (client->server key). Mirrors koreserver SecureChannelManager.handleRekeySignal.
-    //
-    // Serialized on the outbound lock so the generation swap + ack encrypt cannot interleave
-    // with a concurrent outgoing encrypt (which would read a half-swapped key/counter).
+    // Install the server-signalled new generation and ack it on the new gen; serialized on outboundLock.
     handleRekeySignal(controlMsg) {
         const result = this.outboundLock.then(async () => {
             if (this.state !== STATE.SECURE) throw new Error('channel_not_secure');
@@ -328,7 +321,7 @@ class SecureChannel {
             if (typeof newGen !== 'number' || newGen !== this.generation + 1) {
                 throw new Error('rekey_invalid_generation');
             }
-            await this.installGeneration(newGen); // derives new keys, resets c2sSeq/s2cSeq
+            await this.installGeneration(newGen);
             const iv = ivFromCounter(this.c2sSeq);
             const plainBuf = utf8encode(JSON.stringify({ __control: MSG.REKEY_ACK, acceptedGen: newGen }));
             const { ct, tag } = await aesGcmEncrypt(this.k_c2s, iv, plainBuf);

--- a/src/components/secureChannel/secureChannel.js
+++ b/src/components/secureChannel/secureChannel.js
@@ -1,5 +1,4 @@
-// Browser-side secure channel client: ECDH + AES-GCM via window.crypto.subtle,
-// wire-compatible with koreserver/services/SecureChannel/.
+// Browser-side secure channel client: ECDH + AES-GCM via window.crypto.subtle
 
 const PROTOCOL_VERSION = 'rtm-ecdh-v1';
 const NONCE_BYTES = 16;
@@ -30,7 +29,6 @@ const MSG = {
 const HANDSHAKE_TOKEN_C2S = 'rtm-handshake-ok';
 const HANDSHAKE_TOKEN_S2C = 'rtm-handshake-server-ok';
 
-// ---------- encoding helpers ----------
 function b64encode(buf) {
     const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
     let s = '';
@@ -53,14 +51,12 @@ function concatBytes(...arrays) {
 function utf8encode(s) { return new TextEncoder().encode(s); }
 function utf8decode(b) { return new TextDecoder().decode(b); }
 
-// ---------- IV (counter-based) ----------
-function ivFromCounter(counter /* BigInt */) {
+function ivFromCounter(counter) {
     if (counter < 0n || counter >= (1n << 63n)) {
         throw new Error('counter_overflow_force_rekey');
     }
     const iv = new Uint8Array(IV_BYTES);
     const view = new DataView(iv.buffer);
-    // 4 leading zero bytes already set; write counter as BE uint64 at offset 4
     const hi = Number((counter >> 32n) & 0xffffffffn);
     const lo = Number(counter & 0xffffffffn);
     view.setUint32(IV_BYTES - 8, hi, false);
@@ -68,7 +64,6 @@ function ivFromCounter(counter /* BigInt */) {
     return iv;
 }
 
-// ---------- subtle helpers ----------
 async function importAesGcmKey(rawBytes) {
     return window.crypto.subtle.importKey(
         'raw', rawBytes,
@@ -81,7 +76,6 @@ async function aesGcmEncrypt(aesKey, iv, plainBuf) {
         { name: 'AES-GCM', iv },
         aesKey, plainBuf,
     );
-    // SubtleCrypto AES-GCM returns ciphertext || tag. Split.
     const total = new Uint8Array(out);
     const tag = total.slice(total.length - TAG_BYTES);
     const ct = total.slice(0, total.length - TAG_BYTES);
@@ -108,7 +102,6 @@ async function hkdfDerive(sharedSecret, salt, info, lengthBytes) {
     return new Uint8Array(bits);
 }
 
-// SubjectPublicKeyInfo prefix for an uncompressed P-256 EC raw point.
 const SPKI_PREFIX_P256 = new Uint8Array([
     0x30, 0x59, 0x30, 0x13, 0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01,
     0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07, 0x03, 0x42, 0x00,
@@ -137,7 +130,7 @@ async function ecdhDeriveSharedSecret(privateKey, peerRawPub) {
 }
 
 async function importEcdsaVerifyKey(pemPublicKey) {
-    // Strip PEM headers; decode base64 to DER bytes
+    //decode base64 to DER bytes
     const b64 = pemPublicKey.replace(/-----BEGIN [^-]+-----|-----END [^-]+-----|\s+/g, '');
     const der = b64decode(b64);
     return window.crypto.subtle.importKey(
@@ -147,10 +140,7 @@ async function importEcdsaVerifyKey(pemPublicKey) {
     );
 }
 
-// ECDSA signatures from Node's crypto come in DER format. Web Crypto wants
-// raw r||s (64 bytes for P-256). Convert.
 function derToJoseEcdsaP256(derBytes) {
-    // DER: 0x30 len 0x02 lenR R 0x02 lenS S
     const view = new Uint8Array(derBytes);
     if (view[0] !== 0x30) throw new Error('bad_der_signature');
     let offset = 2;
@@ -162,7 +152,6 @@ function derToJoseEcdsaP256(derBytes) {
     if (view[offset] !== 0x02) throw new Error('bad_der_signature_s');
     const sLen = view[offset + 1];
     let s = view.slice(offset + 2, offset + 2 + sLen);
-    // Strip leading zeros and left-pad to 32 bytes
     if (r[0] === 0x00 && r.length === 33) r = r.slice(1);
     if (s[0] === 0x00 && s.length === 33) s = s.slice(1);
     const rOut = new Uint8Array(32); rOut.set(r, 32 - r.length);
@@ -170,15 +159,12 @@ function derToJoseEcdsaP256(derBytes) {
     return concatBytes(rOut, sOut);
 }
 
-// ---------- main class ----------
+// Secure channel
 class SecureChannel {
     constructor({ pinnedPublicKeyPem, sessionId, expectedSigningKeyId } = {}) {
         if (!pinnedPublicKeyPem) {
             throw new Error('SecureChannel: pinnedPublicKeyPem is required');
         }
-        // Fail fast on malformed PEM so callers see a clear error at
-        // construction time rather than an opaque importKey() rejection
-        // mid-handshake (which kills the channel after a network round-trip).
         if (typeof pinnedPublicKeyPem !== 'string'
             || !/-----BEGIN [A-Z ]*PUBLIC KEY-----/.test(pinnedPublicKeyPem)
             || !/-----END [A-Z ]*PUBLIC KEY-----/.test(pinnedPublicKeyPem)) {
@@ -201,10 +187,6 @@ class SecureChannel {
         this.c2sSeq = 0n;
         this.s2cSeq = 0n;
 
-        // Serialization locks. SubtleCrypto operations yield to the event
-        // loop, so without these the counters can be read by two concurrent
-        // callers before either has incremented — causing IV reuse on encrypt
-        // (catastrophic for AES-GCM) and counter desync on decrypt.
         this.outboundLock = Promise.resolve();
         this.inboundLock = Promise.resolve();
     }
@@ -213,7 +195,7 @@ class SecureChannel {
         if (this.state !== STATE.INIT) throw new Error('handshake_state_invalid');
         const kp = await window.crypto.subtle.generateKey(
             { name: 'ECDH', namedCurve: 'P-256' },
-            false, // not extractable — keeps private key inside SubtleCrypto
+            false,
             ['deriveBits'],
         );
         this.privateKey = kp.privateKey;
@@ -241,7 +223,7 @@ class SecureChannel {
         const s2cNonce = b64decode(msg.s2cNonce);
         const sigDer = b64decode(msg.sig);
 
-        // Verify the server signature
+        // verify the server signature
         const verifyKey = await importEcdsaVerifyKey(this.pinnedPublicKeyPem);
         const sigInput = concatBytes(
             this.publicKeyRaw, serverPubBuf,
@@ -262,7 +244,7 @@ class SecureChannel {
         this.sessionId = msg.sessionId;
         await this.installGeneration(0);
 
-        // Build the encrypted complete message
+        // build the encrypted complete message
         const iv = ivFromCounter(this.c2sSeq);
         const plainBuf = utf8encode(HANDSHAKE_TOKEN_C2S);
         const { ct, tag } = await aesGcmEncrypt(this.k_c2s, iv, plainBuf);
@@ -292,10 +274,6 @@ class SecureChannel {
         this.state = STATE.SECURE;
     }
 
-    // Serialized via outboundLock: each call awaits the previous one. This
-    // guarantees one outbound encrypt is in-flight at a time, so c2sSeq is
-    // never read by two parallel callers — preventing AES-GCM IV reuse, the
-    // forbidden-attack condition for confidentiality.
     encryptOutgoing(plainObj) {
         const result = this.outboundLock.then(async () => {
             if (this.state !== STATE.SECURE) throw new Error('channel_not_secure');
@@ -311,16 +289,10 @@ class SecureChannel {
                 tag: b64encode(tag),
             };
         });
-        // Chain regardless of outcome so the queue keeps moving on failure.
         this.outboundLock = result.catch(() => undefined);
         return result;
     }
 
-    // Serialized via inboundLock. WebSocket delivers frames in order, but
-    // when the message handler is async, the JS event loop can dispatch the
-    // next frame before the previous decrypt completes. Without this lock the
-    // second decrypt would read a stale s2cSeq, fail iv_sequence_mismatch,
-    // and permanently desync the channel.
     decryptIncoming(envelope) {
         const result = this.inboundLock.then(async () => {
             if (this.state !== STATE.SECURE) throw new Error('channel_not_secure');

--- a/src/components/secureChannel/secureChannelController.js
+++ b/src/components/secureChannel/secureChannelController.js
@@ -168,4 +168,3 @@ class SecureChannelController {
 }
 
 export default SecureChannelController;
-export { SecureChannelController };

--- a/src/components/secureChannel/secureChannelController.js
+++ b/src/components/secureChannel/secureChannelController.js
@@ -1,0 +1,222 @@
+// Secure-channel controller — lives at the RTM transport chokepoint.
+//
+// One instance is created by chatWindow (which has the pinned-key config) and
+// injected into the KoreRTMClient as `rtmClient._secureChannel`. The RTM client
+// calls this controller at exactly two places:
+//   - send()           -> processOutgoing(frame)  (encrypt before ws.send)
+//   - handleWsMessage() -> processIncoming(frame)  (decrypt after JSON.parse, before emit)
+// and on socket teardown:
+//   - handleWsClose()  -> reset()                  (drop keys so reconnect re-handshakes)
+//
+// Putting encrypt/decrypt here (instead of in a chatWindow sendMessage wrapper)
+// means EVERY frame — user messages, delivery acks, agentDesktop sends — is
+// encrypted uniformly and encrypted AFTER enrichment; and every inbound frame is
+// decrypted ONCE and the plaintext reaches all bot.on('message') listeners.
+//
+// Handshake frames (key_exchange_*) and rekey control frames are driven here and
+// are never themselves encrypted; they go out via the injected rawSend (the RTM
+// client's plaintext write path).
+
+import SecureChannel, { MSG } from './secureChannel.js';
+
+const HANDSHAKE_TIMEOUT_MS = 10000;
+
+class SecureChannelController {
+    // config: { pinnedPublicKeyPem, expectedSigningKeyId }
+    // rawSend: (frameObj) => void   — writes a plaintext frame straight to the socket
+    // logger:  (msg) => void        — optional debug sink
+    constructor({ config, rawSend, logger } = {}) {
+        this.config = config || {};
+        this.rawSend = typeof rawSend === 'function' ? rawSend : function () {};
+        this.logger = typeof logger === 'function' ? logger : function () {};
+        this.channel = null;
+        this.handshakeTimer = null;
+        // Serializes inbound handling so a rekey generation-install completes
+        // before the next frame is decrypted (a new-gen envelope must not race
+        // the install and trip generation_mismatch).
+        this._inbound = Promise.resolve();
+        // Outbound frames requested while the handshake is mid-flight are held
+        // here and flushed (encrypted) once SECURE — this closes the plaintext
+        // window during (re)handshake instead of leaking them in the clear.
+        this._outboundQueue = [];
+    }
+
+    isSecure() { return !!(this.channel && this.channel.isSecure()); }
+
+    // Is this an inbound frame the secure channel owns? Used by the RTM client
+    // to decide whether to route the frame through processIncoming.
+    isRelevant(message) {
+        if (!message || typeof message !== 'object') return false;
+        const t = message.type;
+        return t === MSG.CAPABILITIES || t === MSG.RESPONSE || t === MSG.ACK
+            || t === MSG.INIT || t === MSG.COMPLETE || t === MSG.ENVELOPE;
+    }
+
+    // --- lifecycle ---------------------------------------------------------
+
+    // Drop the channel and fail any queued sends. Called on ws close so the
+    // NEXT connection performs a fresh handshake instead of reusing dead keys.
+    reset(reason) {
+        this._clearTimer();
+        this.channel = null;
+        const queued = this._outboundQueue;
+        this._outboundQueue = [];
+        const err = new Error('secure_channel_reset' + (reason ? ':' + reason : ''));
+        queued.forEach((item) => { try { item.reject(err); } catch (e) { /* noop */ } });
+    }
+
+    _clearTimer() {
+        if (this.handshakeTimer) { clearTimeout(this.handshakeTimer); this.handshakeTimer = null; }
+    }
+
+    _armTimer() {
+        this._clearTimer();
+        this.handshakeTimer = setTimeout(() => {
+            if (this.channel && !this.channel.isSecure()) {
+                this.logger('[secureChannel] handshake timed out — resetting');
+                this.reset('handshake_timeout');
+            }
+        }, HANDSHAKE_TIMEOUT_MS);
+    }
+
+    // --- outbound ----------------------------------------------------------
+
+    // Returns a Promise resolving to the frame that should actually be written.
+    // - SECURE + normal frame -> encrypted envelope
+    // - SECURE + handshake/control frame -> unchanged (already an envelope/plaintext handshake)
+    // - handshaking -> queued, resolves with the envelope after SECURE
+    // - not engaged -> unchanged (server has not required encryption)
+    processOutgoing(frame) {
+        if (this.isSecure()) {
+            if (this._isProtocolFrame(frame)) return Promise.resolve(frame);
+            return this.channel.encryptOutgoing(frame);
+        }
+        if (this.channel) {
+            // handshake in progress — never leak plaintext; hold until SECURE
+            return new Promise((resolve, reject) => {
+                this._outboundQueue.push({ frame, resolve, reject });
+            });
+        }
+        return Promise.resolve(frame);
+    }
+
+    _isProtocolFrame(frame) {
+        const t = frame && frame.type;
+        return t === MSG.INIT || t === MSG.COMPLETE || t === MSG.ACK
+            || t === MSG.ENVELOPE || t === MSG.REKEY_SIGNAL || t === MSG.REKEY_ACK;
+    }
+
+    _flushOutbound() {
+        const queued = this._outboundQueue;
+        this._outboundQueue = [];
+        queued.forEach((item) => {
+            this.channel.encryptOutgoing(item.frame).then(item.resolve).catch(item.reject);
+        });
+    }
+
+    // --- inbound -----------------------------------------------------------
+
+    // Returns Promise<{ handled: boolean, plaintext?: object }>.
+    //   handled=true               -> protocol frame consumed; do not emit
+    //   handled=false, plaintext   -> emit the decrypted object to listeners
+    //   handled=false (no plain)   -> not ours; caller emits the original frame
+    processIncoming(frame) {
+        const run = this._inbound.then(() => this._handleIncoming(frame));
+        this._inbound = run.catch(() => undefined);
+        return run;
+    }
+
+    async _handleIncoming(frame) {
+        const t = frame && frame.type;
+
+        // Server advertises "encryption required" -> start the handshake.
+        if (t === MSG.CAPABILITIES) {
+            // #3 re-entry guard: a duplicate capabilities frame (e.g. after a
+            // reconnect race) must NOT tear down a live channel and reopen a
+            // plaintext window. Ignore it while a channel already exists.
+            if (this.channel) { this.logger('[secureChannel] duplicate capabilities ignored'); return { handled: true }; }
+            if (frame.encryption !== 'required') return { handled: true };
+            const pem = this.config.pinnedPublicKeyPem;
+            if (!pem) { this.logger('[secureChannel] capabilities received but no pinnedPublicKeyPem configured'); return { handled: true }; }
+            try {
+                this.channel = new SecureChannel({
+                    pinnedPublicKeyPem: pem,
+                    expectedSigningKeyId: this.config.expectedSigningKeyId,
+                });
+                this._armTimer();
+                const init = await this.channel.initiateHandshake();
+                this.rawSend(init);
+            } catch (e) {
+                this.logger('[secureChannel] handshake init failed: ' + (e && e.message));
+                this.reset('init_failed');
+            }
+            return { handled: true };
+        }
+
+        // key_exchange_response -> reply with key_exchange_complete.
+        if (t === MSG.RESPONSE) {
+            if (!this.channel || this.channel.isSecure()) { return { handled: true }; }
+            try {
+                const complete = await this.channel.handleResponse(frame);
+                this.rawSend(complete);
+            } catch (e) {
+                this.logger('[secureChannel] handleResponse failed: ' + (e && e.message));
+                this.reset('response_failed');
+            }
+            return { handled: true };
+        }
+
+        // key_exchange_ack -> channel becomes SECURE.
+        if (t === MSG.ACK) {
+            if (!this.channel) return { handled: true };
+            // #2 guard: a duplicate/redelivered ack after we are already SECURE
+            // must be ignored, NOT reset to plaintext.
+            if (this.channel.isSecure()) { this.logger('[secureChannel] duplicate ack ignored'); return { handled: true }; }
+            try {
+                await this.channel.handleAck(frame);
+                this._clearTimer();
+                this._flushOutbound();
+                this.logger('[secureChannel] channel SECURE');
+            } catch (e) {
+                this.logger('[secureChannel] handleAck failed: ' + (e && e.message));
+                this.reset('ack_failed');
+            }
+            return { handled: true };
+        }
+
+        // secure_envelope -> decrypt (control frames handled here, chat surfaced).
+        if (t === MSG.ENVELOPE) {
+            if (!this.channel || !this.channel.isSecure()) {
+                this.logger('[secureChannel] envelope before SECURE — dropping');
+                return { handled: true };
+            }
+            let plain;
+            try {
+                plain = await this.channel.decryptIncoming(frame);
+            } catch (e) {
+                this.logger('[secureChannel] decrypt failed: ' + (e && e.message));
+                return { handled: true };
+            }
+            if (plain && plain.__control === MSG.REKEY_SIGNAL) {
+                try {
+                    const ack = await this.channel.handleRekeySignal(plain);
+                    this.rawSend(ack);
+                    this.logger('[secureChannel] rekeyed to gen ' + plain.newGen);
+                } catch (e) {
+                    this.logger('[secureChannel] rekey failed: ' + (e && e.message));
+                    this.reset('rekey_failed');
+                }
+                return { handled: true };
+            }
+            if (plain && plain.__control === MSG.REKEY_ACK) {
+                return { handled: true };
+            }
+            return { handled: false, plaintext: plain };
+        }
+
+        return { handled: false };
+    }
+}
+
+export default SecureChannelController;
+export { SecureChannelController };

--- a/src/components/secureChannel/secureChannelController.js
+++ b/src/components/secureChannel/secureChannelController.js
@@ -4,10 +4,9 @@ import SecureChannel, { MSG } from './secureChannel.js';
 const HANDSHAKE_TIMEOUT_MS = 10000;
 
 class SecureChannelController {
-    constructor({ config, rawSend, logger } = {}) {
+    constructor({ config, rawSend } = {}) {
         this.config = config || {};
         this.rawSend = typeof rawSend === 'function' ? rawSend : function () {};
-        this.logger = typeof logger === 'function' ? logger : function () {};
         this.channel = null;
         this.handshakeTimer = null;
         this._inbound = Promise.resolve();
@@ -41,7 +40,6 @@ class SecureChannelController {
         this._clearTimer();
         this.handshakeTimer = setTimeout(() => {
             if (this.channel && !this.channel.isSecure()) {
-                this.logger('[secureChannel] handshake timed out — resetting');
                 this.reset('handshake_timeout');
             }
         }, HANDSHAKE_TIMEOUT_MS);
@@ -87,10 +85,10 @@ class SecureChannelController {
 
         if (t === MSG.CAPABILITIES) {
             // Ignore a duplicate capabilities frame — never tear down a live channel.
-            if (this.channel) { this.logger('[secureChannel] duplicate capabilities ignored'); return { handled: true }; }
+            if (this.channel) return { handled: true };
             if (frame.encryption !== 'required') return { handled: true };
             const pem = this.config.pinnedPublicKeyPem;
-            if (!pem) { this.logger('[secureChannel] capabilities received but no pinnedPublicKeyPem configured'); return { handled: true }; }
+            if (!pem) return { handled: true };
             try {
                 this.channel = new SecureChannel({
                     pinnedPublicKeyPem: pem,
@@ -100,19 +98,17 @@ class SecureChannelController {
                 const init = await this.channel.initiateHandshake();
                 this.rawSend(init);
             } catch (e) {
-                this.logger('[secureChannel] handshake init failed: ' + (e && e.message));
                 this.reset('init_failed');
             }
             return { handled: true };
         }
 
         if (t === MSG.RESPONSE) {
-            if (!this.channel || this.channel.isSecure()) { return { handled: true }; }
+            if (!this.channel || this.channel.isSecure()) return { handled: true };
             try {
                 const complete = await this.channel.handleResponse(frame);
                 this.rawSend(complete);
             } catch (e) {
-                this.logger('[secureChannel] handleResponse failed: ' + (e && e.message));
                 this.reset('response_failed');
             }
             return { handled: true };
@@ -121,38 +117,30 @@ class SecureChannelController {
         if (t === MSG.ACK) {
             if (!this.channel) return { handled: true };
             // Ignore a duplicate/redelivered ack once SECURE — do not reset to plaintext.
-            if (this.channel.isSecure()) { this.logger('[secureChannel] duplicate ack ignored'); return { handled: true }; }
+            if (this.channel.isSecure()) return { handled: true };
             try {
                 await this.channel.handleAck(frame);
                 this._clearTimer();
                 this._flushOutbound();
-                this.logger('[secureChannel] channel SECURE');
             } catch (e) {
-                this.logger('[secureChannel] handleAck failed: ' + (e && e.message));
                 this.reset('ack_failed');
             }
             return { handled: true };
         }
 
         if (t === MSG.ENVELOPE) {
-            if (!this.channel || !this.channel.isSecure()) {
-                this.logger('[secureChannel] envelope before SECURE — dropping');
-                return { handled: true };
-            }
+            if (!this.channel || !this.channel.isSecure()) return { handled: true };
             let plain;
             try {
                 plain = await this.channel.decryptIncoming(frame);
             } catch (e) {
-                this.logger('[secureChannel] decrypt failed: ' + (e && e.message));
                 return { handled: true };
             }
             if (plain && plain.__control === MSG.REKEY_SIGNAL) {
                 try {
                     const ack = await this.channel.handleRekeySignal(plain);
                     this.rawSend(ack);
-                    this.logger('[secureChannel] rekeyed to gen ' + plain.newGen);
                 } catch (e) {
-                    this.logger('[secureChannel] rekey failed: ' + (e && e.message));
                     this.reset('rekey_failed');
                 }
                 return { handled: true };

--- a/src/components/secureChannel/secureChannelController.js
+++ b/src/components/secureChannel/secureChannelController.js
@@ -1,50 +1,21 @@
-// Secure-channel controller — lives at the RTM transport chokepoint.
-//
-// One instance is created by chatWindow (which has the pinned-key config) and
-// injected into the KoreRTMClient as `rtmClient._secureChannel`. The RTM client
-// calls this controller at exactly two places:
-//   - send()           -> processOutgoing(frame)  (encrypt before ws.send)
-//   - handleWsMessage() -> processIncoming(frame)  (decrypt after JSON.parse, before emit)
-// and on socket teardown:
-//   - handleWsClose()  -> reset()                  (drop keys so reconnect re-handshakes)
-//
-// Putting encrypt/decrypt here (instead of in a chatWindow sendMessage wrapper)
-// means EVERY frame — user messages, delivery acks, agentDesktop sends — is
-// encrypted uniformly and encrypted AFTER enrichment; and every inbound frame is
-// decrypted ONCE and the plaintext reaches all bot.on('message') listeners.
-//
-// Handshake frames (key_exchange_*) and rekey control frames are driven here and
-// are never themselves encrypted; they go out via the injected rawSend (the RTM
-// client's plaintext write path).
-
+// Secure-channel controller — encrypt/decrypt at the RTM transport chokepoint.
 import SecureChannel, { MSG } from './secureChannel.js';
 
 const HANDSHAKE_TIMEOUT_MS = 10000;
 
 class SecureChannelController {
-    // config: { pinnedPublicKeyPem, expectedSigningKeyId }
-    // rawSend: (frameObj) => void   — writes a plaintext frame straight to the socket
-    // logger:  (msg) => void        — optional debug sink
     constructor({ config, rawSend, logger } = {}) {
         this.config = config || {};
         this.rawSend = typeof rawSend === 'function' ? rawSend : function () {};
         this.logger = typeof logger === 'function' ? logger : function () {};
         this.channel = null;
         this.handshakeTimer = null;
-        // Serializes inbound handling so a rekey generation-install completes
-        // before the next frame is decrypted (a new-gen envelope must not race
-        // the install and trip generation_mismatch).
         this._inbound = Promise.resolve();
-        // Outbound frames requested while the handshake is mid-flight are held
-        // here and flushed (encrypted) once SECURE — this closes the plaintext
-        // window during (re)handshake instead of leaking them in the clear.
         this._outboundQueue = [];
     }
 
     isSecure() { return !!(this.channel && this.channel.isSecure()); }
 
-    // Is this an inbound frame the secure channel owns? Used by the RTM client
-    // to decide whether to route the frame through processIncoming.
     isRelevant(message) {
         if (!message || typeof message !== 'object') return false;
         const t = message.type;
@@ -52,10 +23,7 @@ class SecureChannelController {
             || t === MSG.INIT || t === MSG.COMPLETE || t === MSG.ENVELOPE;
     }
 
-    // --- lifecycle ---------------------------------------------------------
-
-    // Drop the channel and fail any queued sends. Called on ws close so the
-    // NEXT connection performs a fresh handshake instead of reusing dead keys.
+    // Drop the channel on ws close so the next connection re-handshakes with fresh keys.
     reset(reason) {
         this._clearTimer();
         this.channel = null;
@@ -79,20 +47,13 @@ class SecureChannelController {
         }, HANDSHAKE_TIMEOUT_MS);
     }
 
-    // --- outbound ----------------------------------------------------------
-
-    // Returns a Promise resolving to the frame that should actually be written.
-    // - SECURE + normal frame -> encrypted envelope
-    // - SECURE + handshake/control frame -> unchanged (already an envelope/plaintext handshake)
-    // - handshaking -> queued, resolves with the envelope after SECURE
-    // - not engaged -> unchanged (server has not required encryption)
+    // Encrypt outgoing when SECURE; queue while handshaking so nothing leaks plaintext.
     processOutgoing(frame) {
         if (this.isSecure()) {
             if (this._isProtocolFrame(frame)) return Promise.resolve(frame);
             return this.channel.encryptOutgoing(frame);
         }
         if (this.channel) {
-            // handshake in progress — never leak plaintext; hold until SECURE
             return new Promise((resolve, reject) => {
                 this._outboundQueue.push({ frame, resolve, reject });
             });
@@ -114,12 +75,7 @@ class SecureChannelController {
         });
     }
 
-    // --- inbound -----------------------------------------------------------
-
-    // Returns Promise<{ handled: boolean, plaintext?: object }>.
-    //   handled=true               -> protocol frame consumed; do not emit
-    //   handled=false, plaintext   -> emit the decrypted object to listeners
-    //   handled=false (no plain)   -> not ours; caller emits the original frame
+    // Serialized so a rekey generation-install completes before the next frame is decrypted.
     processIncoming(frame) {
         const run = this._inbound.then(() => this._handleIncoming(frame));
         this._inbound = run.catch(() => undefined);
@@ -129,11 +85,8 @@ class SecureChannelController {
     async _handleIncoming(frame) {
         const t = frame && frame.type;
 
-        // Server advertises "encryption required" -> start the handshake.
         if (t === MSG.CAPABILITIES) {
-            // #3 re-entry guard: a duplicate capabilities frame (e.g. after a
-            // reconnect race) must NOT tear down a live channel and reopen a
-            // plaintext window. Ignore it while a channel already exists.
+            // Ignore a duplicate capabilities frame — never tear down a live channel.
             if (this.channel) { this.logger('[secureChannel] duplicate capabilities ignored'); return { handled: true }; }
             if (frame.encryption !== 'required') return { handled: true };
             const pem = this.config.pinnedPublicKeyPem;
@@ -153,7 +106,6 @@ class SecureChannelController {
             return { handled: true };
         }
 
-        // key_exchange_response -> reply with key_exchange_complete.
         if (t === MSG.RESPONSE) {
             if (!this.channel || this.channel.isSecure()) { return { handled: true }; }
             try {
@@ -166,11 +118,9 @@ class SecureChannelController {
             return { handled: true };
         }
 
-        // key_exchange_ack -> channel becomes SECURE.
         if (t === MSG.ACK) {
             if (!this.channel) return { handled: true };
-            // #2 guard: a duplicate/redelivered ack after we are already SECURE
-            // must be ignored, NOT reset to plaintext.
+            // Ignore a duplicate/redelivered ack once SECURE — do not reset to plaintext.
             if (this.channel.isSecure()) { this.logger('[secureChannel] duplicate ack ignored'); return { handled: true }; }
             try {
                 await this.channel.handleAck(frame);
@@ -184,7 +134,6 @@ class SecureChannelController {
             return { handled: true };
         }
 
-        // secure_envelope -> decrypt (control frames handled here, chat surfaced).
         if (t === MSG.ENVELOPE) {
             if (!this.channel || !this.channel.isSecure()) {
                 this.logger('[secureChannel] envelope before SECURE — dropping');

--- a/src/components/secureChannel/secureChannelController.js
+++ b/src/components/secureChannel/secureChannelController.js
@@ -22,7 +22,6 @@ class SecureChannelController {
             || t === MSG.INIT || t === MSG.COMPLETE || t === MSG.ENVELOPE;
     }
 
-    // Drop the channel on ws close so the next connection re-handshakes with fresh keys.
     reset(reason) {
         this._clearTimer();
         this.channel = null;
@@ -45,7 +44,6 @@ class SecureChannelController {
         }, HANDSHAKE_TIMEOUT_MS);
     }
 
-    // Encrypt outgoing when SECURE; queue while handshaking so nothing leaks plaintext.
     processOutgoing(frame) {
         if (this.isSecure()) {
             if (this._isProtocolFrame(frame)) return Promise.resolve(frame);
@@ -73,7 +71,6 @@ class SecureChannelController {
         });
     }
 
-    // Serialized so a rekey generation-install completes before the next frame is decrypted.
     processIncoming(frame) {
         const run = this._inbound.then(() => this._handleIncoming(frame));
         this._inbound = run.catch(() => undefined);
@@ -84,7 +81,6 @@ class SecureChannelController {
         const t = frame && frame.type;
 
         if (t === MSG.CAPABILITIES) {
-            // Ignore a duplicate capabilities frame — never tear down a live channel.
             if (this.channel) return { handled: true };
             if (frame.encryption !== 'required') return { handled: true };
             const pem = this.config.pinnedPublicKeyPem;
@@ -116,7 +112,6 @@ class SecureChannelController {
 
         if (t === MSG.ACK) {
             if (!this.channel) return { handled: true };
-            // Ignore a duplicate/redelivered ack once SECURE — do not reset to plaintext.
             if (this.channel.isSecure()) return { handled: true };
             try {
                 await this.channel.handleAck(frame);


### PR DESCRIPTION
  ## Summary

  Adds opt-in **application-layer ECDH + AES-GCM encryption** to the chat                                                                                                                                 
  WebSocket / REST traffic. Activates only when the SDK app on the server
  has `duplexEncryptionEnabled: true` (a new flag landing in **koreserver                                                                                                                                 
  PR XOP-30265** and toggled via **builder-ui PR XOP-30265**).                                                                                                                                            
                                                                                                                                                                                                          
  ## What's new                                                                                                                                                                                           
                                                                                                                                                                                                          
  - `src/components/secureChannel/secureChannel.js` — browser ECDH P-256 +                                                                                                                                
    HKDF-SHA256 + AES-256-GCM client built on `window.crypto.subtle`.                                                                                                                                   
  - `src/components/chatwindow/chatWindow.ts` — handler intercept + send                                                                                                                                  
    wrap; server-driven activation via `protocol_capabilities` frame.                                                                                                                                     
                                                                                                                                                                                                          
  ## Safety properties (in response to review feedback)                                                                                                                                                   
                                                                                                                                                                                                          
  - **Concurrency**: `encryptOutgoing` / `decryptIncoming` serialize via                                                                                                                                  
    per-direction promise locks. Without this, IV reuse on encrypt
    (catastrophic for AES-GCM) and counter desync on decrypt would occur                                                                                                                                  
    when WS frames arrive faster than crypto ops complete.                                                                                                                                                
  - **Fail closed**: encryption failure drops the message and surfaces the                                                                                                                                
    error — does NOT silently fall back to plaintext.                                                                                                                                                     
                                                                                                                                                                                                        
  ## Related PRs                                                                                                                                                                                          
                                                                                                                                                                                                        
  - **koreserver** — server-side handshake, flag plumbing, DB migration                                                                                                                                   
  - **builder-ui** — per-app toggle UI                                                                                                                                                                  
                                                                                                                                                                                                          
  ---
                                                                                                                                                                                                          
  ## 🚀 Deployment checklist                                                                                                                                                                            

  ### Pre-deploy (coordination with koreserver + devops)                                                                                                                                                  
   
  - [ ] Receive per-environment **signing public key** (`pub.pem`) from                                                                                                                                   
        devops. One per env — never share keys across envs.                                                                                                                                         
        ```                                                                                                                                                                                               
        sit / staging / prod  →  three different keypairs
        ```                                                                                                                                                                                               
  - [ ] Receive the matching **`signingKeyId`** for each env                                                                                                                                            
        (e.g. `kid-prod-2026-Q2`).                                                                                                                                                                        
  - [ ] Decide distribution strategy:
        - **(A)** Bake env-specific pubkey into per-env SDK bundle                                                                                                                                        
          (`koreapi.dev.bundle.js`, `koreapi.prod.bundle.js`, etc.).                                                                                                                                      
          Most secure, hardest to rotate.                                                                                                                                                                 
        - **(B)** Document for customers to paste into their `chatConfig`                                                                                                                                 
          when initializing. Most flexible, customer-driven.                                                                                                                                              
        - **(C, future)** Bootstrap endpoint                                                                                                                                                            
          `/api/v1/secure-channel/keys` — SDK fetches at runtime.                                                                                                                                         
                                                                                                                                                                                                          
  ### Customer-facing config (chatConfig)                                                                                                                                                                 
                                                                                                                                                                                                          
  ```js                                                                                                                                                                                                 
  botOptions.secureChannel = {
    pinnedPublicKeyPem:
  `-----BEGIN PUBLIC KEY-----
  <server's public key for the env you're connecting to>                                                                                                                                                  
  -----END PUBLIC KEY-----`,                                                                                                                                                                              
    expectedSigningKeyId: "kid-prod-2026-Q2"   // matches server config                                                                                                                                   
  };                                                                                                                                                                                                      
  ```                                                                                                                                                                                                   
                                                                                                                                                                                                          
  - [ ] Update SDK integration docs with these two new fields.                                                                                                                                            
   
  ### Compatibility expectations                                                                                                                                                                          
                                                                                                                                                                                                        
  - [ ] Customers on **this SDK version** + app flag ON  → encrypted chat                                                                                                                                 
  - [ ] Customers on **older SDK** + app flag ON           → handshake times out
        → connection closes cleanly. Customer must upgrade SDK before account                                                                                                                             
        admin flips the app toggle. Document this hard cutover in release notes.                                                                                                                        
  - [ ] Customers on any SDK + app flag OFF                → legacy plaintext,                                                                                                                            
        unchanged.                                                                                                                                                                                        
                                                                                                                                                                                                          
  ### Smoke test                                                                                                                                                                                          
                                                                                                                                                                                                          
  - [ ] Build SDK, paste env's pinned pubkey, hard-refresh chat.
  - [ ] DevTools → Network → WS → confirm `key_exchange_*` frames then                                                                                                                                    
        `secure_envelope` frames flow (rather than plain JSON).                                                                                                                                           