### PR TITLE
PLAT-67655 - 71759 | Typing indicator overlaps user messages due to C…

### DIFF
--- a/src/components/chatwindow/chatWindow.ts
+++ b/src/components/chatwindow/chatWindow.ts
@@ -1942,6 +1942,10 @@ showTypingIndicator  () {
     $('.typingIndicatorContent').css('display', 'block');
   } else {
     me.chatEle.querySelector('.typing-indicator-wraper').style.display = 'flex';
+    const chatBodyWrapper = me.chatEle.querySelector('.chat-widget-body-wrapper');
+    if (chatBodyWrapper) {
+      chatBodyWrapper.style.paddingBottom = '30px';
+    }
   }
 };
 hideTypingIndicator  () {
@@ -1950,6 +1954,10 @@ hideTypingIndicator  () {
     $('.typingIndicatorContent').css('display', 'none');
   } else {
     me.chatEle.querySelector('.typing-indicator-wraper').style.display = 'none';
+    const chatBodyWrapper = me.chatEle.querySelector('.chat-widget-body-wrapper');
+    if (chatBodyWrapper) {
+      chatBodyWrapper.style.paddingBottom = '';
+    }
   }
 };
 renderMessage  (msgData: { createdOnTimemillis: number; createdOn: string | number | Date; type: string; icon: any; message: { component: { payload: { fromHistory: any; }; }; }[]; messageId: any; renderType: string; fromHistorySync: any; } | any) {

--- a/src/components/chatwindow/chatWindow.ts
+++ b/src/components/chatwindow/chatWindow.ts
@@ -1942,10 +1942,6 @@ showTypingIndicator  () {
     $('.typingIndicatorContent').css('display', 'block');
   } else {
     me.chatEle.querySelector('.typing-indicator-wraper').style.display = 'flex';
-    const chatBodyWrapper = me.chatEle.querySelector('.chat-widget-body-wrapper');
-    if (chatBodyWrapper) {
-      chatBodyWrapper.style.paddingBottom = '30px';
-    }
   }
 };
 hideTypingIndicator  () {
@@ -1954,10 +1950,6 @@ hideTypingIndicator  () {
     $('.typingIndicatorContent').css('display', 'none');
   } else {
     me.chatEle.querySelector('.typing-indicator-wraper').style.display = 'none';
-    const chatBodyWrapper = me.chatEle.querySelector('.chat-widget-body-wrapper');
-    if (chatBodyWrapper) {
-      chatBodyWrapper.style.paddingBottom = '';
-    }
   }
 };
 renderMessage  (msgData: { createdOnTimemillis: number; createdOn: string | number | Date; type: string; icon: any; message: { component: { payload: { fromHistory: any; }; }; }[]; messageId: any; renderType: string; fromHistorySync: any; } | any) {

--- a/src/templatemanager/base/chatWidgetComposeBar/chatWidgetComposeBar.scss
+++ b/src/templatemanager/base/chatWidgetComposeBar/chatWidgetComposeBar.scss
@@ -612,14 +612,15 @@
 // Typing Indicator
 .typing-indicator-wraper{
     position: absolute;
-    top: -30px;
-    left: 16px;
+    top: -28px;
+    left: 0;
     width: auto;
-    min-width: 120px;
+    min-width: 116px;
     display: none;
     align-items: center;
     gap: 20px;
-    padding: 4px 0;
+    padding: 4px 0 4px 16px;
+    border-radius: 0px 6px 6px 0px;
     background: var(--sdk-global-white-bg);
     z-index: 9;
     p{


### PR DESCRIPTION
Typing indicator overlaps user messages due to CSS position property in chat widget

Usually, the typing indicator hides once the user message is sent. Here, we implemented a smooth typing indicator transition so that when the typing indicator is removed, the chat body does not jump or glitch. We achieved this by using position: absolute, which allows the typing indicator to disappear smoothly without affecting the message layout.

As mentioned in the ticket, the background color is the same as the chat body because we are using 4-variable color mapping across the application. We also adjusted the chat body padding and typing indicator border radius accordingly. If we remove the typing indicator background, the typing text overlaps with the messages.

Regarding the solution shared by the customer, we can implement it. However, with that approach, when the typing indicator hides or gets removed, the chat body jump issue will occur. That is the reason we are not using that solution. Usually, typing indicators overlay the messages to avoid layout shifting.
