### PR TITLE
PLAT-71047: Truncate carousel button titles

### DIFF
--- a/UI/chatWindow.css
+++ b/UI/chatWindow.css
@@ -1859,6 +1859,9 @@
     cursor: pointer;
     max-width: 242px;
     padding-top: 13px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .kore-chat-window .purejscarousel-btn {

--- a/UI/chatWindow.js
+++ b/UI/chatWindow.js
@@ -3653,7 +3653,7 @@
                                         {{if msgItem.default_action && msgItem.default_action.type === "web_url"}}<div class="listItemPath carouselDefaultAction" type="url" url="${msgItem.default_action.url}">${msgItem.default_action.url}</div>{{/if}} \
                                         {{if msgItem.buttons}} \
                                             {{each(key, msgBtn) msgItem.buttons}} \
-                                                <div {{if msgBtn.payload}}value="${msgBtn.payload}"{{/if}} {{if msgBtn.url}}url="${msgBtn.url}"{{/if}} class="listItemPath carouselButton" data-value="${msgBtn.value}" type="${msgBtn.type}">\
+                                                <div {{if msgBtn.payload}}value="${msgBtn.payload}"{{/if}} {{if msgBtn.url}}url="${msgBtn.url}"{{/if}} class="listItemPath carouselButton" data-value="${msgBtn.value}" type="${msgBtn.type}" title="${msgBtn.title}">\
                                                     ${msgBtn.title}\
                                                 </div> \
                                             {{/each}} \


### PR DESCRIPTION
## Summary\n- Truncate long carousel button labels with an ellipsis.\n- Show the complete button title on hover.\n\nPLAT-71047