### PR TITLE
PLAT-71047: Truncate carousel button titles

### DIFF
--- a/src/templatemanager/templates/carouselTemplate/carouselTemplate.scss
+++ b/src/templatemanager/templates/carouselTemplate/carouselTemplate.scss
@@ -82,6 +82,10 @@
 .kore-chat-window .carouselTitleBox .carouselButton {
     width: 242px;
     height: 48px;
+    box-sizing: border-box;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
     background-color: transparent;
     border-top: solid 1px var(--sdk-chat-widow-primary-border-color);
     font-size: 15px;

--- a/src/templatemanager/templates/carouselTemplate/carouselTemplate.ts
+++ b/src/templatemanager/templates/carouselTemplate/carouselTemplate.ts
@@ -101,7 +101,7 @@ class CarouselTemplate {
                                 {{if msgItem.default_action && msgItem.default_action.type === "web_url"}}<div class="listItemPath carouselDefaultAction" type="url" url="${msgItem.default_action.url}">${msgItem.default_action.url}</div>{{/if}} \
                                 {{if msgItem.buttons}} \
                                     {{each(key, msgBtn) msgItem.buttons}} \
-                                        <div {{if msgBtn.payload}}value="${msgBtn.payload}"{{/if}} {{if msgBtn.url}}url="${msgBtn.url}"{{/if}} class="listItemPath carouselButton" data-value="${msgBtn.value}" type="${msgBtn.type}">\
+                                        <div {{if msgBtn.payload}}value="${msgBtn.payload}"{{/if}} {{if msgBtn.url}}url="${msgBtn.url}"{{/if}} class="listItemPath carouselButton" data-value="${msgBtn.value}" title="${msgBtn.title}" type="${msgBtn.type}">\
                                             ${msgBtn.title}\
                                         </div> \
                                     {{/each}} \


### PR DESCRIPTION
## Summary
- truncate carousel button titles with an ellipsis when they exceed the supported display width
- preserve the complete button title on hover

## Ticket
PLAT-71047